### PR TITLE
add chai plugin "chai-as-promised"

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ["mocha", "chai"],
+    frameworks: ["mocha", "chai", "chai-as-promised"],
 
     // list of files/patterns to load in the browser
     files: [{ pattern: "spec.bundle.js", watched: false }],
@@ -15,6 +15,7 @@ module.exports = function (config) {
 
     plugins: [
       require("karma-chai"),
+      require("karma-chai-plugins"),
       require("karma-chrome-launcher"),
       require("karma-coverage"),
       require("karma-mocha"),

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "http-proxy-middleware": "^0.17.0",
     "karma": "^1.1.2",
     "karma-chai": "^0.1.0",
+    "karma-chai-plugins": "^0.8.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-junit-reporter": "^1.1.0",


### PR DESCRIPTION
chai-as-promised helps to handle promises more easily.

Added the npm package "karma-chai-plugins", which includes
chai-as-promised and makes it possible to include it in the
karma.conf.js as a framework.