### PR TITLE
Replaced karma-chai-plugins

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ["mocha", "chai", "chai-as-promised"],
+    frameworks: ["mocha", "chai-as-promised", "chai"],
 
     // list of files/patterns to load in the browser
     files: [{ pattern: "spec.bundle.js", watched: false }],
@@ -15,7 +15,7 @@ module.exports = function (config) {
 
     plugins: [
       require("karma-chai"),
-      require("karma-chai-plugins"),
+      require("karma-chai-as-promised"),
       require("karma-chrome-launcher"),
       require("karma-coverage"),
       require("karma-mocha"),

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "http-proxy-middleware": "^0.17.0",
     "karma": "^1.1.2",
     "karma-chai": "^0.1.0",
-    "karma-chai-plugins": "^0.8.0",
+    "karma-chai-as-promised": "^0.1.2",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-junit-reporter": "^1.1.0",


### PR DESCRIPTION
use karma-chai-as-promised instead, since it has less unneeded plugins