### PR TITLE
Enforce no trailing spaces also on blank lines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,7 +68,7 @@
     "no-sparse-arrays": 2,
     "no-this-before-super": 2,
     "no-throw-literal": 2,
-    "no-trailing-spaces": [2, { "skipBlankLines": true }],
+    "no-trailing-spaces": [2, { "skipBlankLines": false }],
     "no-undef": 2,
     "no-unexpected-multiline": 2,
     "no-unreachable": 2,


### PR DESCRIPTION
Differences between editors resulted in ugly diffs, which are annoying
if you want to see the actual changes.