### PR TITLE
Remove unused new rootScope in tests

### DIFF
--- a/client/app/components/_createPickup/createPickup.spec.js
+++ b/client/app/components/_createPickup/createPickup.spec.js
@@ -7,7 +7,7 @@ import PickupDate from "../../common/pickupDate/pickupDate";
 const { module } = angular.mock;
 
 describe("CreatePickup", () => {
-  let $rootScope, $componentController, $httpBackend;
+  let $componentController, $httpBackend;
 
   beforeEach(module(CreatePickupModule));
   beforeEach(module(PickupDate));
@@ -22,7 +22,6 @@ describe("CreatePickup", () => {
 
   beforeEach(inject(($injector) => {
     $httpBackend = $injector.get("$httpBackend");
-    $rootScope = $injector.get("$rootScope");
     $componentController = $injector.get("$componentController");
   }));
 
@@ -43,7 +42,6 @@ describe("CreatePickup", () => {
 
     beforeEach(() => {
       controller = $componentController("createPickup", {
-        $scope: $rootScope.$new()
       }, {
         storeId: 2,
         pickuplistCtrl: {

--- a/client/app/components/_pickupList/pickupList.spec.js
+++ b/client/app/components/_pickupList/pickupList.spec.js
@@ -5,7 +5,7 @@ import AuthenticationModule from "../../common/authentication/authentication";
 import PickupDateModule from "../../common/pickupDate/pickupDate";
 
 describe("PickupList", () => {
-  let $rootScope, $componentController, $httpBackend;
+  let $componentController, $httpBackend;
 
   let { module } = angular.mock;
 
@@ -22,7 +22,6 @@ describe("PickupList", () => {
     });
     inject(($injector) => {
       $httpBackend = $injector.get("$httpBackend");
-      $rootScope = $injector.get("$rootScope");
       $componentController = $injector.get("$componentController");
     });
   });
@@ -205,7 +204,6 @@ describe("PickupList", () => {
 
     beforeEach(() => {
       controller = $componentController("pickupList", {
-        $scope: $rootScope.$new()
       }, {
         storeId: 9,
         options: {
@@ -261,7 +259,6 @@ describe("PickupList", () => {
 
     beforeEach(() => {
       controller = $componentController("pickupList", {
-        $scope: $rootScope.$new()
       }, {
         storeId: 9,
         options: {

--- a/client/app/components/_pickupList/pickupListItem/pickupListItem.spec.js
+++ b/client/app/components/_pickupList/pickupListItem/pickupListItem.spec.js
@@ -1,7 +1,7 @@
 import PickupListItemModule from "./pickupListItem";
 
 describe("PickupListItem", () => {
-  let $rootScope, $componentController, $httpBackend, $q;
+  let $componentController, $httpBackend, $q;
 
   let { module } = angular.mock;
 
@@ -11,7 +11,6 @@ describe("PickupListItem", () => {
 
   beforeEach(inject(($injector) => {
     $httpBackend = $injector.get("$httpBackend");
-    $rootScope = $injector.get("$rootScope");
     $componentController = $injector.get("$componentController");
     $q = $injector.get("$q");
 
@@ -44,7 +43,6 @@ describe("PickupListItem", () => {
 
     beforeEach(() => {
       controller = $componentController("pickupListItem", {
-        $scope: $rootScope.$new()
       }, {
         data: pickupData,
         parentCtrl: {
@@ -68,7 +66,6 @@ describe("PickupListItem", () => {
 
     beforeEach(() => {
       $ctrl = $componentController("pickupListItem", {
-        $scope: $rootScope.$new()
       }, {
         data: pickupData,
         showDetail: "store"

--- a/client/app/components/_storeList/storeList.spec.js
+++ b/client/app/components/_storeList/storeList.spec.js
@@ -2,7 +2,7 @@ import StoreListModule from "./storeList";
 import StoreModule from "../../common/store/store";
 
 describe("StoreList", () => {
-  let $rootScope, $componentController, $httpBackend;
+  let $componentController, $httpBackend;
 
   let { module } = angular.mock;
 
@@ -11,7 +11,6 @@ describe("StoreList", () => {
 
   beforeEach(inject(($injector) => {
     $httpBackend = $injector.get("$httpBackend");
-    $rootScope = $injector.get("$rootScope");
     $componentController = $injector.get("$componentController");
   }));
 
@@ -35,7 +34,6 @@ describe("StoreList", () => {
 
     it("check binding of complete stores",() => {
       controller = $componentController("storeList", {
-        $scope: $rootScope.$new()
       }, {
         stores: [storeOne]
       });
@@ -46,7 +44,6 @@ describe("StoreList", () => {
 
     it("maps stores-array",() => {
       controller = $componentController("storeList", {
-        $scope: $rootScope.$new()
       }, {
         stores: [1]
       });

--- a/client/app/components/_userList/userList.spec.js
+++ b/client/app/components/_userList/userList.spec.js
@@ -2,7 +2,7 @@ import UserListModule from "./userList";
 import UserModule from "../../common/user/user";
 
 describe("UserList", () => {
-  let $rootScope, $componentController, $httpBackend;
+  let $componentController, $httpBackend;
 
   let { module } = angular.mock;
 
@@ -11,7 +11,6 @@ describe("UserList", () => {
 
   beforeEach(inject(($injector) => {
     $httpBackend = $injector.get("$httpBackend");
-    $rootScope = $injector.get("$rootScope");
     $componentController = $injector.get("$componentController");
   }));
 
@@ -39,7 +38,6 @@ describe("UserList", () => {
 
     it("check binding of complete users",() => {
       controller = $componentController("userList", {
-        $scope: $rootScope.$new()
       }, {
         users: [userOne]
       });
@@ -50,7 +48,6 @@ describe("UserList", () => {
 
     it("maps users-array",() => {
       controller = $componentController("userList", {
-        $scope: $rootScope.$new()
       }, {
         users: [1]
       });


### PR DESCRIPTION
According to docs, the default behaviour creates an isolated scope. If
we want to use the scope in the tests, we should define it as local var.
https://puigcerber.com/2016/02/07/how-to-test-angular-1-5-components/