### PR TITLE
Add button to return to groupDetail

### DIFF
--- a/client/app/components/_groupMenu/groupMenu.html
+++ b/client/app/components/_groupMenu/groupMenu.html
@@ -1,7 +1,8 @@
+<md-button ui-sref="groupDetail({ id: $ctrl.activeGroup.id })">
+  {{$ctrl.activeGroup.name || "Please choose a group..."}}
+</md-button>
 <md-menu md-offset="0 50" md-ink-ripple>
-
  <a ng-click="$ctrl.openMenu($mdOpenMenu, $event)" class="md-button">
-   {{$ctrl.activeGroup.name || "Please choose a group..."}}
    <i class="fa fa-caret-down md-caption"></i>
  </a>
  <md-menu-content>


### PR DESCRIPTION
When I click on the group name, I expect to see the group home page, not
the group menu.