### PR TITLE
Remove usages of first_name and last_name

### DIFF
--- a/client/app/common/authentication/authentication.spec.js
+++ b/client/app/common/authentication/authentication.spec.js
@@ -16,8 +16,6 @@ describe("authentication", () => {
   let loginData = {
     "id": 7,
     "display_name": "asdflo",
-    "first_name": null,
-    "last_name": null,
     "email": "asdf.asdf@asdf.asdf",
     "address": null,
     "latitude": null,

--- a/client/app/common/user/user.spec.js
+++ b/client/app/common/user/user.spec.js
@@ -9,8 +9,6 @@ describe("user service", () => {
   let userData = [{
     "id": 1,
     "display_name": "Mr T",
-    "first_name": "tilmann",
-    "last_name": "becker",
     "email": "til@man.com",
     "address": null,
     "latitude": null,
@@ -19,15 +17,13 @@ describe("user service", () => {
 
   let userCreateData = [{
     "display_name": "Mr T",
-    "first_name": "tilmann",
-    "last_name": "becker",
     "email": "til@man.com",
     "password": "abc"
   }];
 
   let userModifyData = {
     "id": 1,
-    "last_name": "becker"
+    "display_name": "becker"
   };
 
   beforeEach(inject(($injector) => {

--- a/client/app/components/_userList/userList.html
+++ b/client/app/components/_userList/userList.html
@@ -1,6 +1,6 @@
 <md-list layout-padding>
   <md-list-item ng-repeat="user in $ctrl.userData" ng-click="$ctrl.onClick(user)">
-    <p>{{user.first_name}} {{user.last_name}} (@{{user.display_name}})</p>
+    <p>{{user.display_name}}</p>
     <md-button ng-show="$ctrl.showEdit" class="md-secondary md-icon-button" aria-label="Edit" ng-click="editUser(user)">
       <i class="fa fa-pencil" aria-hidden="true"></i>
     </md-button>

--- a/client/app/components/signup/signup.controller.js
+++ b/client/app/components/signup/signup.controller.js
@@ -5,8 +5,6 @@ class SignupController {
       name: "signup",
       User,
       $state,
-      firstName: "",
-      lastName: "",
       username: "",
       email: "",
       password: "",
@@ -22,8 +20,6 @@ class SignupController {
     /* eslint-disable camelcase */
     let user = {
       display_name: this.username,
-      first_name: this.firstName,
-      last_name: this.lastName,
       email: this.email,
       password: this.password
     };

--- a/client/app/components/signup/signup.html
+++ b/client/app/components/signup/signup.html
@@ -21,17 +21,6 @@
           <input type="password" required name="password" ng-model="$ctrl.password">
         </md-input-container>
 
-        <div flex>
-          <md-input-container>
-            <label translate="USERDATA.FIRSTNAME"></label>
-            <input required type="text" ng-model="$ctrl.firstName">
-          </md-input-container>
-          <md-input-container>
-            <label translate="USERDATA.LASTNAME"></label>
-            <input required type="text" ng-model="$ctrl.lastName">
-          </md-input-container>
-        </div>
-
         <md-button-container flex>
           <md-button ui-sref="login">
             <span translate="SIGNUP.BACK"></span>

--- a/client/app/components/signup/signup.spec.js
+++ b/client/app/components/signup/signup.spec.js
@@ -44,8 +44,6 @@ describe("Signup", () => {
 
       let signupRequest = {
         "display_name": "test",
-        "first_name": "test",
-        "last_name": "test",
         "email": "test@test.org",
         "password": "123"
       };
@@ -53,8 +51,6 @@ describe("Signup", () => {
       let signupResponse = {
         "id": 55,
         "display_name": "test",
-        "first_name": "test",
-        "last_name": "test",
         "email": "test@test.org"
       };
 
@@ -63,8 +59,6 @@ describe("Signup", () => {
         let ctrl = $componentController("signup", {});
         Object.assign(ctrl, {
           username: signupRequest.display_name,
-          firstName: signupRequest.first_name,
-          lastName: signupRequest.last_name,
           email: signupRequest.email,
           password: signupRequest.password,
           passwordrepeat: signupRequest.password

--- a/client/app/locales/locale-de.json
+++ b/client/app/locales/locale-de.json
@@ -2,9 +2,7 @@
   "USERDATA": {
     "EMAIL": "E-Mail",
     "PASSWORD": "Passwort",
-    "USERNAME": "Name",
-    "FIRSTNAME": "Vorname",
-    "LASTNAME": "Nachname"
+    "USERNAME": "Name"
   },
   "BUTTON": {
     "CREATE": "Erstellen",

--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -2,9 +2,7 @@
   "USERDATA": {
     "EMAIL": "Mail",
     "PASSWORD": "Password",
-    "USERNAME": "Name",
-    "FIRSTNAME": "First Name",
-    "LASTNAME": "Last Name"
+    "USERNAME": "Name"
   },
   "BUTTON": {
     "CREATE": "Create",


### PR DESCRIPTION
They are not really needed for basic usage. Also, it seems to depend on
the community what kind of "name" they need (just a user name, a serious
name, the same as on the passport), so this should remodeled together
with the potential users.

Closes #105.