### PR TITLE
Add geocoding service

### DIFF
--- a/client/app/common/geocoding/geocoding.js
+++ b/client/app/common/geocoding/geocoding.js
@@ -1,0 +1,9 @@
+import Geocoding from "./geocoding.service";
+
+let geocodingModule = angular.module("Geocoding", [])
+
+.service("Geocoding", Geocoding)
+
+.name;
+
+export default geocodingModule;

--- a/client/app/common/geocoding/geocoding.service.js
+++ b/client/app/common/geocoding/geocoding.service.js
@@ -1,0 +1,23 @@
+class GeocodingService {
+  constructor($http) {
+    "ngInject";
+    Object.assign(this, {
+      $http
+    });
+  }
+
+  lookupAddress(address) {
+    return this.$http.get("https://nominatim.openstreetmap.org/search", {
+      params: { format: "json", limit: 1, q: address }
+    }).then((data) => {
+      let hit = data.data[0];
+      return {
+        latitude: parseFloat(hit.lat),
+        longitude: parseFloat(hit.lon),
+        name: hit.display_name
+      };
+    });
+  }
+}
+
+export default GeocodingService;

--- a/client/app/common/geocoding/geocoding.spec.js
+++ b/client/app/common/geocoding/geocoding.spec.js
@@ -1,0 +1,39 @@
+import GeocodingModule from "./geocoding";
+
+const { module } = angular.mock;
+
+describe("geocoding", () => {
+  let $httpBackend, Geocoding;
+  beforeEach(() => {
+    module(GeocodingModule);
+  });
+
+  beforeEach(inject(($injector) => {
+    $httpBackend = $injector.get("$httpBackend");
+    Geocoding = $injector.get("Geocoding");
+  }));
+
+  afterEach(() => {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it("gets coords for address", () => {
+    let latlonname = [{
+      lat: "1.99",
+      lon: "2.99",
+      display_name: "something" // eslint-disable-line
+    }];
+    $httpBackend.expectGET("https://nominatim.openstreetmap.org/search?format=json&limit=1&q=enter_some")
+      .respond(latlonname);
+    expect(Geocoding.lookupAddress("enter_some"))
+      .to.be.fulfilled.and
+      .to.eventually.deep.equal({
+        latitude: 1.99,
+        longitude: 2.99,
+        name: "something"
+      });
+    $httpBackend.flush();
+  });
+
+});


### PR DESCRIPTION
Lookup address via Nominatim, will be used by the map integration #130.

Only use first result. Don't do explicit error handling for now, promise seems to
get rejected when no hit occurs (via exception).