### PR TITLE
Nest store into groups

### DIFF
--- a/client/app/components/_groupMenu/groupMenu.controller.js
+++ b/client/app/components/_groupMenu/groupMenu.controller.js
@@ -24,7 +24,7 @@ class GroupMenuController {
       targetEvent: $event,
       template: "<join-group></join-group>"
     }).then((groupId) => {
-      this.$state.go("groupDetail", { id: groupId });
+      this.$state.go("groupDetail", { groupId });
     });
   }
 }

--- a/client/app/components/_groupMenu/groupMenu.html
+++ b/client/app/components/_groupMenu/groupMenu.html
@@ -1,5 +1,5 @@
 <div layout="row" layout-nowrap id="group-menu-container">
-  <md-button ui-sref="groupDetail({ id: $ctrl.activeGroup.id })" id="group-menu-active-group" flex>
+  <md-button ui-sref="groupDetail({ groupId: $ctrl.activeGroup.id })" id="group-menu-active-group" flex>
     {{$ctrl.activeGroup.name || "Please choose a group..."}}
   </md-button>
   <md-menu md-ink-ripple>
@@ -9,7 +9,7 @@
    <md-menu-content>
      <md-menu-item ng-repeat="groupitem in $ctrl.groups"
                    ng-if="groupitem.id !== $ctrl.activeGroup.id">
-       <md-button ui-sref="groupDetail({ id: groupitem.id })">
+       <md-button ui-sref="groupDetail({ groupId: groupitem.id })">
          <i class="fa fa-circle-o"> </i>
          {{ groupitem.name }}
        </md-button>

--- a/client/app/components/_groupMenu/groupMenu.spec.js
+++ b/client/app/components/_groupMenu/groupMenu.spec.js
@@ -30,7 +30,7 @@ describe("GroupMenu", () => {
       }));
       $ctrl.openJoinGroupDialog();
       $rootScope.$apply();
-      expect($state.go).to.have.been.calledWith( "groupDetail", { id: 1337 } );
+      expect($state.go).to.have.been.calledWith( "groupDetail", { groupId: 1337 } );
     });
   });
 });

--- a/client/app/components/_pickupList/pickupListItem/pickupListItem.html
+++ b/client/app/components/_pickupList/pickupListItem/pickupListItem.html
@@ -6,7 +6,7 @@
         <span ng-if="$ctrl.showStoreDetail">
           <i ng-if="!$ctrl.storeData" class="fa fa-spinner"></i>
           <a ng-if="$ctrl.storeData"
-             ui-sref="storeDetail({ id: $ctrl.storeData.id })">
+             ui-sref="storeDetail({ storeId: $ctrl.storeData.id, groupId: $ctrl.storeData.group })">
             {{$ctrl.storeData.name}}
           </a>
         </span>

--- a/client/app/components/_storeList/_storeMap/storeMap.controller.js
+++ b/client/app/components/_storeList/_storeMap/storeMap.controller.js
@@ -40,7 +40,7 @@ class StoreMapController {
       markers[e.id] = {
         lat: e.latitude,
         lng: e.longitude,
-        message: "<a ui-sref='storeDetail({ id: " + e.id + "})'>" + e.name + "</a>",
+        message: `<a ui-sref='storeDetail({ storeId: ${e.id}, groupId: ${e.group} })'>${e.name}</a>`,
         draggable: false
       };
     });

--- a/client/app/components/_storeList/_storeMap/storeMap.spec.js
+++ b/client/app/components/_storeList/_storeMap/storeMap.spec.js
@@ -25,11 +25,15 @@ describe("StoreMap", () => {
       let $ctrl = component.isolateScope().$ctrl;
       expect($ctrl.hasMarkers()).to.be.false;
 
-      $scope.storeData = [{ id: 99, latitude: 1.99, longitude: 2.99, name: "test1" }];
+      $scope.storeData = [{ id: 99, group: 5, latitude: 1.99, longitude: 2.99, name: "test1" }];
       $scope.$apply();
       expect($ctrl.hasMarkers()).to.be.true;
       expect($ctrl.markers).to.deep.equal({
-        99: { lat: 1.99, lng: 2.99, message: "<a ui-sref='storeDetail({ id: 99})'>test1</a>", draggable: false }
+        99: {
+          lat: 1.99,
+          lng: 2.99,
+          message: "<a ui-sref='storeDetail({ storeId: 99, groupId: 5 })'>test1</a>",
+          draggable: false }
       });
     });
   });

--- a/client/app/components/_storeList/_storeMap/storeMap.spec.js
+++ b/client/app/components/_storeList/_storeMap/storeMap.spec.js
@@ -34,7 +34,7 @@ describe("StoreMap", () => {
       let $ctrl = component.isolateScope().$ctrl;
       expect($ctrl.hasMarkers()).to.be.false;
 
-      $scope.storeData = [{ id: 99, group: 5, latitude: 1.99, longitude: 2.99, name: "test1" }];
+      $scope.storeList = [{ id: 99, group: 5, latitude: 1.99, longitude: 2.99, name: "test1" }];
       $scope.$apply();
       expect($ctrl.hasMarkers()).to.be.true;
       expect($ctrl.markers).to.deep.equal({

--- a/client/app/components/_storeList/storeList.controller.js
+++ b/client/app/components/_storeList/storeList.controller.js
@@ -35,7 +35,7 @@ class StoreListController {
     if (angular.isDefined(this.callback)) {
       this.callback(store);
     } else {
-      this.$state.go( "storeDetail", { id: store.id } );
+      this.$state.go( "storeDetail", { storeId: store.id, groupId: store.group } );
     }
   }
 

--- a/client/app/components/_storeList/storeList.html
+++ b/client/app/components/_storeList/storeList.html
@@ -4,7 +4,7 @@
     <i style="font-size: 1.2em;" class="fa fa-plus-circle" aria-hidden="true"></i>
     <span translate="BUTTON.CREATE"></span>
   </md-button>
-  <md-list-item ng-repeat="store in $ctrl.storeList" ui-sref="storeDetail({ id: store.id })">
+  <md-list-item ng-repeat="store in $ctrl.storeList" ui-sref="storeDetail({ storeId: store.id, groupId: store.group })">
     <p>{{store.name}}</p>
   </md-list-item>
 </md-list>

--- a/client/app/components/_storeList/storeList.spec.js
+++ b/client/app/components/_storeList/storeList.spec.js
@@ -41,16 +41,19 @@ describe("StoreList", () => {
     });
 
     it("gets store data",() => {
-      let $ctrl = $componentController("storeList");
-      $httpBackend.expectGET("/api/stores/").respond([storeOne]);
+      let $ctrl = $componentController("storeList", {}, { groupId: 67 });
+      $httpBackend.expectGET("/api/stores/?group=67").respond([storeOne]);
       $httpBackend.flush();
       expect($ctrl.storeList).to.deep.equal([storeOne]);
     });
 
     it("opens dialog to create store", () => {
-      let $ctrl = $componentController("storeList");
-      $httpBackend.expectGET("/api/stores/").respond([]);
+      // from controller init, could be mocked away
+      let $ctrl = $componentController("storeList", {}, { groupId: 67 });
+      $httpBackend.expectGET("/api/stores/?group=67").respond([]);
       $httpBackend.flush();
+
+      // real test
       $mdDialog.show.returns($q((resolve) => {
         resolve({ id: 999 });
       }));

--- a/client/app/components/createGroup/createGroup.controller.js
+++ b/client/app/components/createGroup/createGroup.controller.js
@@ -10,7 +10,7 @@ class CreateGroupController {
 
   createGroup() {
     this.Group.create(this.groupData).then((data) => {
-      this.$state.go("groupDetail", { id: data.id });
+      this.$state.go("groupDetail", { groupId: data.id });
     }).catch((error) => {
       this.error = error.data;
     });

--- a/client/app/components/createGroup/createGroup.spec.js
+++ b/client/app/components/createGroup/createGroup.spec.js
@@ -33,7 +33,7 @@ describe("CreateGroup", () => {
         name: "blabla"
       }).respond(201, { id: 987 });
       $httpBackend.flush();
-      expect($state.go).to.have.been.calledWith("groupDetail", { id: 987 });
+      expect($state.go).to.have.been.calledWith("groupDetail", { groupId: 987 });
     });
 
     it("fails to create group", () => {

--- a/client/app/components/groupDetail/groupDetail.html
+++ b/client/app/components/groupDetail/groupDetail.html
@@ -33,7 +33,7 @@
         <span translate="GROUP.STORES"></span>
       </md-tab-label>
       <md-tab-body>
-        <store-list group-id="$ctrl.groupId"></store-list>
+        <store-list group-id="$ctrl.groupdata.id"></store-list>
       </md-tab-body>
     </md-tab>
   </md-tabs>

--- a/client/app/components/groupDetail/groupDetail.js
+++ b/client/app/components/groupDetail/groupDetail.js
@@ -21,17 +21,17 @@ let groupDetailModule = angular.module("groupDetail", [
   $stateProvider
     .state("groupDetail", {
       parent: "main",
-      url: "/group/{id:int}",
+      url: "/group/{groupId:int}",
       component: "groupDetail",
       resolve: {
         groupdata: (Group, CurrentGroup, $stateParams) => {
-          return Group.get($stateParams.id).then((group) => {
+          return Group.get($stateParams.groupId).then((group) => {
             CurrentGroup.set(group);
             return group;
           });
         },
         stores: (Store, $stateParams) => {
-          return Store.listByGroupId($stateParams.id);
+          return Store.listByGroupId($stateParams.groupId);
         }
       }
     });

--- a/client/app/components/groupDetail/groupDetail.spec.js
+++ b/client/app/components/groupDetail/groupDetail.spec.js
@@ -101,7 +101,7 @@ describe("GroupDetail", () => {
     let groupData = { id: 12 };
     it("should load group information", () => {
       $httpBackend.expectGET(`/api/groups/${groupData.id}/`).respond(groupData);
-      $state.go("groupDetail", { id: groupData.id });
+      $state.go("groupDetail", { groupId: groupData.id });
       $httpBackend.flush();
       expect($state.current.component).to.equal("groupDetail");
     });

--- a/client/app/components/home/home.controller.js
+++ b/client/app/components/home/home.controller.js
@@ -10,7 +10,7 @@ class HomeController {
 
     this.Group.listMy().then((data) => {
       if (data.length > 0) {
-        $state.go("groupDetail", { id: data[0].id });
+        $state.go("groupDetail", { groupId: data[0].id });
       } else {
         this.openJoinGroupDialog();
       }
@@ -23,7 +23,7 @@ class HomeController {
       targetEvent: $event,
       template: "<join-group></join-group>"
     }).then((groupId) => {
-      this.$state.go("groupDetail", { id: groupId });
+      this.$state.go("groupDetail", { groupId });
     });
   }
 

--- a/client/app/components/home/home.spec.js
+++ b/client/app/components/home/home.spec.js
@@ -45,7 +45,7 @@ describe("Home", () => {
       $httpBackend.expectGET("/api/groups/?members=1").respond(200, groupData);
       $componentController("home", {});
       $httpBackend.flush();
-      expect($state.go).to.have.been.calledWith("groupDetail", { id: 50 });
+      expect($state.go).to.have.been.calledWith("groupDetail", { groupId: 50 });
     });
 
     it("opens join group dialog", () => {
@@ -55,7 +55,7 @@ describe("Home", () => {
       }));
       $componentController("home", {});
       $httpBackend.flush();
-      expect($state.go).to.have.been.calledWith( "groupDetail", { id: 1337 } );
+      expect($state.go).to.have.been.calledWith( "groupDetail", { groupId: 1337 } );
     });
   });
 });

--- a/client/app/components/storeDetail/storeDetail.js
+++ b/client/app/components/storeDetail/storeDetail.js
@@ -21,25 +21,18 @@ let storeDetailModule = angular.module("storeDetail", [
   $stateProvider
     .state("storeDetail", {
       parent: "main",
-      url: "/store/:id",
+      url: "/group/{groupId:int}/store/{storeId:int}",
       component: "storeDetail",
       resolve: {
-
         storedata: (Store, $stateParams) => {
-          return Store.get($stateParams.id);
+          return Store.get($stateParams.storeId);
         },
-
-        /**
-          Loads the group for this store, and sets it as the current group
-        */
-        groupdata: (storedata, Group, CurrentGroup) => {
-          "ngInject";
-          return Group.get(storedata.group).then((group) => {
+        groupdata: (Group, CurrentGroup, $stateParams) => {
+          return Group.get($stateParams.groupId).then((group) => {
             CurrentGroup.set(group);
             return group;
           });
         }
-
       }
     });
   hookProvider.setup("storeDetail", { authenticated: true, anonymous: "login" });

--- a/client/app/components/storeDetail/storeDetail.spec.js
+++ b/client/app/components/storeDetail/storeDetail.spec.js
@@ -60,9 +60,7 @@ describe("StoreDetail", () => {
 
       describe("storeDetail", () => {
 
-        let groupData = {
-          id: 12
-        };
+        let groupData = { id: 12 };
 
         let storeData = {
           id: 25,
@@ -72,18 +70,12 @@ describe("StoreDetail", () => {
         it("should load store and group information", () => {
           $httpBackend.expectGET(`/api/stores/${storeData.id}/`).respond(storeData);
           $httpBackend.expectGET(`/api/groups/${groupData.id}/`).respond(groupData);
-          $state.go("storeDetail", { id: storeData.id });
+          $state.go("storeDetail", { storeId: storeData.id, groupId: groupData.id });
           $httpBackend.flush();
           expect($state.current.component).to.equal("storeDetail");
         });
-
       });
-
     });
-
-  });
-
-  describe("Template", () => {
   });
 
   describe("Component", () => {


### PR DESCRIPTION
Changes as discussed in #103. I did not nest the states. It doesn't seem fitting: we don't have a parent group page where all the subpages are nested in.

If I would create a parent group page, what should it have? Just a `ui-vieẁ` element to show the subpages?

What would be the subpages?

- storeDetail
- groupDetail
- members
- stores
- pickups