### PR TITLE
PickupDate service only returns upcoming pickups

### DIFF
--- a/client/app/common/pickupDate/pickupDate.service.js
+++ b/client/app/common/pickupDate/pickupDate.service.js
@@ -15,17 +15,17 @@ class PickupDateComService {
   }
 
   list() {
-    return this.$http.get("/api/pickup-dates/")
+    return this.$http.get("/api/pickup-dates/", { params: { "date_0": new Date() } })
       .then((res) => res.data);
   }
 
   listByGroupId(groupId) {
-    return this.$http.get("/api/pickup-dates/", { params: { group: groupId } })
+    return this.$http.get("/api/pickup-dates/", { params: { group: groupId, "date_0": new Date() } })
       .then((res) => res.data);
   }
 
   listByStoreId(storeId) {
-    return this.$http.get("/api/pickup-dates/", { params: { store: storeId } })
+    return this.$http.get("/api/pickup-dates/", { params: { store: storeId, "date_0": new Date() } })
       .then((res) => res.data);
   }
 

--- a/client/app/common/pickupDate/pickupDate.spec.js
+++ b/client/app/common/pickupDate/pickupDate.spec.js
@@ -14,16 +14,22 @@ describe("pickupDate service", () => {
     $log.assertEmpty();
   });
 
-  let $httpBackend, PickupDate;
+  let $httpBackend, PickupDate, now, clock;
 
   beforeEach(inject(($injector) => {
     $httpBackend = $injector.get("$httpBackend");
     PickupDate = $injector.get("PickupDate");
   }));
 
+  beforeEach(() => {
+    now = new Date();
+    clock = sinon.useFakeTimers(now.getTime());
+  });
+
   afterEach(() => {
     $httpBackend.verifyNoOutstandingExpectation();
     $httpBackend.verifyNoOutstandingRequest();
+    clock.restore();
   });
 
   let pickupData = [{
@@ -61,8 +67,8 @@ describe("pickupDate service", () => {
     "store": 9
   };
 
-  it("lists all pickupdates", () => {
-    $httpBackend.expectGET("/api/pickup-dates/").respond(pickupData);
+  it("lists upcoming pickupdates", () => {
+    $httpBackend.expectGET(`/api/pickup-dates/?date_0=${now.toISOString()}`).respond(pickupData);
     expect(PickupDate.list())
       .to.be.fulfilled.and
       .to.eventually.deep.equal(pickupData);
@@ -77,16 +83,16 @@ describe("pickupDate service", () => {
     $httpBackend.flush();
   });
 
-  it("filters pickupdates by store", () => {
-    $httpBackend.expectGET("/api/pickup-dates/?store=9").respond(pickupData[0]);
+  it("filters upcoming pickupdates by store", () => {
+    $httpBackend.expectGET(`/api/pickup-dates/?date_0=${now.toISOString()}&store=9`).respond(pickupData[0]);
     expect(PickupDate.listByStoreId(9))
       .to.be.fulfilled.and
       .to.eventually.deep.equal(pickupData[0]);
     $httpBackend.flush();
   });
 
-  it("filters pickupdates by group", () => {
-    $httpBackend.expectGET("/api/pickup-dates/?group=9").respond(pickupData[0]);
+  it("filters upcoming pickupdates by group", () => {
+    $httpBackend.expectGET(`/api/pickup-dates/?date_0=${now.toISOString()}&group=9`).respond(pickupData[0]);
     expect(PickupDate.listByGroupId(9))
       .to.be.fulfilled.and
       .to.eventually.deep.equal(pickupData[0]);

--- a/client/app/components/_pickupList/pickupList.spec.js
+++ b/client/app/components/_pickupList/pickupList.spec.js
@@ -1,7 +1,7 @@
 import PickupListModule from "./pickupList";
 
 describe("PickupList", () => {
-  let $log, $componentController, $httpBackend;
+  let $log, $componentController, $httpBackend, now, clock;
 
   let { module } = angular.mock;
 
@@ -13,12 +13,15 @@ describe("PickupList", () => {
       $httpBackend = $injector.get("$httpBackend");
       $componentController = $injector.get("$componentController");
     });
+    now = new Date(2016, 8, 1);
+    clock = sinon.useFakeTimers(now.getTime());
   });
 
   afterEach(() => {
     $httpBackend.verifyNoOutstandingExpectation();
     $httpBackend.verifyNoOutstandingRequest();
     $log.assertEmpty();
+    clock.restore();
   });
 
   let authData = {
@@ -202,7 +205,7 @@ describe("PickupList", () => {
       });
 
       $httpBackend.whenGET("/api/auth/status/").respond(authData);
-      $httpBackend.whenGET("/api/pickup-dates/?store=9").respond(pickupData);
+      $httpBackend.whenGET(`/api/pickup-dates/?date_0=${now.toISOString()}&store=9`).respond(pickupData);
     });
 
     afterEach(() => {
@@ -217,7 +220,7 @@ describe("PickupList", () => {
 
     it("automatic update", () => {
       $httpBackend.expectGET("/api/auth/status/").respond(authData);
-      $httpBackend.expectGET("/api/pickup-dates/?store=9").respond(pickupData);
+      $httpBackend.expectGET(`/api/pickup-dates/?date_0=${now.toISOString()}&store=9`).respond(pickupData);
     });
 
 
@@ -258,7 +261,7 @@ describe("PickupList", () => {
       });
 
       $httpBackend.whenGET("/api/auth/status/").respond(authData);
-      $httpBackend.whenGET("/api/pickup-dates/?store=9").respond(pickupData);
+      $httpBackend.whenGET(`/api/pickup-dates/?date_0=${now.toISOString()}&store=9`).respond(pickupData);
       $httpBackend.whenGET("/api/stores/9/").respond(storeData);
     });
 


### PR DESCRIPTION
For now, we only need future pickups.
For historic pickups, we could either add separate methods or add a parameter.

Closes #160 