### PR TITLE
Don't request empty groups from the server

### DIFF
--- a/client/app/common/group/group.service.js
+++ b/client/app/common/group/group.service.js
@@ -18,7 +18,7 @@ class GroupService {
   }
 
   list() {
-    return this.$http.get("/api/groups/")
+    return this.$http.get("/api/groups/", { params: { "include_empty": "False" } })
       .then((res) => res.data);
   }
 

--- a/client/app/common/group/group.spec.js
+++ b/client/app/common/group/group.spec.js
@@ -49,7 +49,7 @@ describe("group service", () => {
   });
 
   it("lists groups", () => {
-    $httpBackend.expectGET("/api/groups/").respond(groupData);
+    $httpBackend.expectGET("/api/groups/?include_empty=False").respond(groupData);
     expect(Group.list())
       .to.be.fulfilled.and
       .to.eventually.deep.equal(groupData);

--- a/client/app/components/_joinGroup/joinGroup.spec.js
+++ b/client/app/components/_joinGroup/joinGroup.spec.js
@@ -36,7 +36,7 @@ describe("JoinGroup", () => {
 
     it("joins group", () => {
       let $ctrl = $componentController("joinGroup", {});
-      $httpBackend.expectGET("/api/groups/").respond([]);
+      $httpBackend.expectGET("/api/groups/?include_empty=False").respond([]);
       $ctrl.joinGroup(1337);
       $httpBackend.expectPOST("/api/groups/1337/join/").respond();
       $httpBackend.expectGET("/api/auth/status/").respond([]);


### PR DESCRIPTION
They aren't shown in the joinGroup dialog anyways, so why request them?