### PR TITLE
Hotfix: groupButton text-overflow: ellipsis

### DIFF
--- a/client/app/components/_groupMenu/groupMenu.html
+++ b/client/app/components/_groupMenu/groupMenu.html
@@ -1,13 +1,14 @@
-<div layout="row" layout-nowrap id="group-menu-container">
+<div layout="row" layout-nowrap id="group-menu-container">  
+  <md-button
+    aria-label="{{$ctrl.activeGroup.name || 'Please choose a group...'}}"
+    ui-sref="group.groupDetail.pickups({ groupId: $ctrl.activeGroup.id })"
+    id="group-menu-active-group"
+    flex>
+    <logo></logo>
+    <span style="text-overflow: ellipsis">{{$ctrl.activeGroup.name || "Please choose a group..."}}</span>
+  </md-button>
   <md-menu md-position-mode="target bottom">
     <span>
-      <md-button
-        aria-label="{{$ctrl.activeGroup.name || 'Please choose a group...'}}"
-        ui-sref="group.groupDetail.pickups({ groupId: $ctrl.activeGroup.id })"
-        id="group-menu-active-group">
-        <logo></logo>
-        {{$ctrl.activeGroup.name || "Please choose a group..."}}
-      </md-button>
       <a ng-click="$ctrl.openMenu($mdOpenMenu, $event)" class="md-button" id="group-menu-group-picker">
         <i class="fa fa-caret-down md-caption"></i>
         <div md-menu-origin class="aligner"></div>

--- a/client/app/components/_topbar/topbar.html
+++ b/client/app/components/_topbar/topbar.html
@@ -1,9 +1,8 @@
 <md-toolbar class="md-medium-small md-whiteframe-3dp">
   <div class="md-toolbar-tools" layout="row" layout-align="space-between center">
     <span flex="5" hide-xs></span>
-    <group-menu style="min-width: 50%"></group-menu>
-
-    <span flex></span>
+    <group-menu style="min-width: 50%" flex></group-menu>
+    
     <language-chooser ng-if="!screenIsSmall"></language-chooser>
     <md-button ng-if="!screenIsSmall" class="userProfileLink" ui-sref="userDetail({id: $ctrl.loggedInUser.id})" aria-label="{{ 'TOPBAR.USERPROFILE' | translate }}">
       <i class="fa fa-user"></i>


### PR DESCRIPTION
The group button was showing two lines with long group names `01_testgroup_with_maps_and_password ` - now it's just `...`-ing it again.