### PR TITLE
refactor: don't nest md-content elements

### DIFF
--- a/client/app/components/_createStore/createStore.html
+++ b/client/app/components/_createStore/createStore.html
@@ -6,7 +6,7 @@
     </h2>
   </div>
 </md-toolbar>
-<md-content layout-padding>
+<div layout-padding>
   <form ng-submit='createStoreForm.$valid && $ctrl.createStore()' name="createStoreForm" layout="column">
     <div flex layout="row" layout-xs="column">
       <div flex layout="column">
@@ -54,4 +54,4 @@
 
     {{ $ctrl.error }}
   </form>
-</md-content>
+</div>

--- a/client/app/components/_joinGroup/joinGroup.html
+++ b/client/app/components/_joinGroup/joinGroup.html
@@ -7,7 +7,7 @@
       </h2>
     </div>
   </md-toolbar>
-  <md-content ng-if="!$ctrl.check" flex style="overflow: auto">
+  <div ng-if="!$ctrl.check" flex style="overflow: auto">
     <md-list style="overflow: visible">
       <md-list-item>
         <span translate="JOINGROUP.NAME"></span>
@@ -37,7 +37,7 @@
         </div>
       </md-list-item>
     </md-list>
-  </md-content>
+  </div>
 
   <md-toolbar ng-if="$ctrl.check">
     <div class="md-toolbar-tools">
@@ -47,7 +47,7 @@
       </h2>
     </div>
   </md-toolbar>
-  <md-content ng-if="$ctrl.check" flex style="overflow: auto">
+  <div ng-if="$ctrl.check" flex style="overflow: auto">
     <form name="form" ng-submit="$ctrl.joinGroup(this)" style="text-align:center">
       <h4 translate="JOINGROUP.PASSWORD_LABEL"></h4>
       <md-input-container>
@@ -64,7 +64,7 @@
         </md-tooltip>
       </md-button>
     </form>
-  </md-content>
+  </div>
 
 
   <md-dialog-actions>

--- a/client/app/components/_pickupList/pickupList.html
+++ b/client/app/components/_pickupList/pickupList.html
@@ -39,7 +39,7 @@
 
 
   <!-- Items -->
-  <md-content style="padding: 0">
+  <div style="padding: 0">
     <section ng-repeat="pickupDate in $ctrl.groupedPickups | orderBy:'date':$ctrl.options.reversed">
       <md-subheader ng-show="$ctrl.options.showStickyHeaders" class="md-sticky">{{pickupDate.date| date:'fullDate'}}</md-subheader>
       <md-list>
@@ -53,15 +53,15 @@
       </md-list>
     </section>
 
-    <md-content ng-if="!$ctrl.isInitialized" layout="row" layout-sm="column" layout-align="space-around">
+    <div ng-if="!$ctrl.isInitialized" layout="row" layout-sm="column" layout-align="space-around">
       <md-progress-circular md-mode="indeterminate" style="margin: 3em auto"></md-progress-circular>
-    </md-content>
+    </div>
 
-    <md-content ng-if="$ctrl.isInitialized && !$ctrl.groupedPickups.length"  layout-padding>
+    <div ng-if="$ctrl.isInitialized && !$ctrl.groupedPickups.length"  layout-padding>
       <h4 style="margin-bottom: 0"><i class="fa fa-bed"></i> <translate>PICKUPLIST.NONE</translate></h4>
       <small ng-if="!$ctrl.options.showCreateButton" translate="PICKUPLIST.NONE_HINT"></small>
-    </md-content>
-  </md-content>
+    </div>
+  </div>
 
   <!-- confirm to delete pickup -->
   <div style="visibility: hidden">

--- a/client/app/components/_topbar/topbar.html
+++ b/client/app/components/_topbar/topbar.html
@@ -31,7 +31,7 @@
   <md-toolbar class="md-theme-light">
     <h1 class="md-toolbar-tools"><span translate="TOPBAR.GREETING" translate-values='{ username: $ctrl.loggedInUser.display_name}'></span></h1>
   </md-toolbar>
-  <md-content layout-padding>
+  <div layout-padding>
     <md-menu-content width="4">
       <md-menu-item>
         <md-button ng-click="$ctrl.toggleRight()" class="userProfileLink" ui-sref="userDetail({id: $ctrl.loggedInUser.id})" aria-label="{{ 'TOPBAR.USERPROFILE' | translate }}">
@@ -48,5 +48,5 @@
     </md-menu-content>
     <hr style="padding:0">
     <language-chooser></language-chooser>
-  </md-content>
+  </div>
 </md-sidenav>

--- a/client/app/components/group/createGroup/createGroup.html
+++ b/client/app/components/group/createGroup/createGroup.html
@@ -9,7 +9,7 @@
         </h1>
       </div>
     </md-toolbar>
-    <md-content>
+    <div>
       <form name="createGroupForm" ng-submit="createGroupForm.$valid && $ctrl.createGroup()" layout="column">
         <group-edit-create-form edit-data="$ctrl.groupData"></group-edit-create-form>
 
@@ -20,7 +20,7 @@
           </md-button>
         </md-button-container>
       </form>
-    </md-content>
+    </div>
   </div>
   <div flex></div>
 </div>

--- a/client/app/components/group/createGroup/createGroup.styl
+++ b/client/app/components/group/createGroup/createGroup.styl
@@ -6,5 +6,5 @@ create-group
     padding: 0
     .fa
         margin-right: 1em
-    md-content
+    form
         padding: 20px

--- a/client/app/components/group/group.html
+++ b/client/app/components/group/group.html
@@ -9,9 +9,9 @@
           <h3 translate="GROUP.STORES"></h3>
         </div>
       </md-toolbar>
-      <md-content>
+      <div>
         <store-list group-id="$ctrl.groupData.id"></store-list>
-      </md-content>
+      </div>
     </div>
   </span>
 

--- a/client/app/components/group/groupDetail/groupDetail.html
+++ b/client/app/components/group/groupDetail/groupDetail.html
@@ -22,7 +22,7 @@
   </div>
 </md-toolbar>
 
-<md-content layout-padding>
+<div layout-padding>
   <div ng-if="$ctrl.groupData.address">
     <i class="fa fa-fw fa-map-marker"></i>
     {{$ctrl.groupData.address}}
@@ -30,7 +30,7 @@
   <div ng-if="$ctrl.$mdMedia('gt-sm')">
     <expandable-panel content="$ctrl.groupData.description" markdown="true" collapse="10"></expandable-panel>
   </div>
-  <md-content class="md-padding">
+  <div class="md-padding">
     <md-nav-bar md-selected-nav-item="$ctrl.currentNavItem" nav-bar-aria-label="navigation links">
       <md-nav-item md-nav-sref="group.groupDetail.pickups" name="pickups">
         <span translate="GROUP.PICKUPS"></span>
@@ -47,8 +47,8 @@
     </md-nav-bar>
 
     <ui-view></ui-view>
-  </md-content>
-</md-content>
+  </div>
+</div>
 
 <!-- confirm to leave group -->
 <div style="visibility: hidden">

--- a/client/app/components/group/store/storeDetail.html
+++ b/client/app/components/group/store/storeDetail.html
@@ -17,7 +17,7 @@
     </md-toolbar>
 
     <store-detail-map ng-if="$ctrl.mapData.latitude && $ctrl.mapData.longitude" store-data="$ctrl.mapData"></store-detail-map>
-    <md-content layout-padding>
+    <div layout-padding>
 
       <div ng-hide="editableStore.$visible">
         <p ng-if="$ctrl.storedata.address">
@@ -54,5 +54,5 @@
       </div>
     </form>
     <pickup-list store-id="$ctrl.storedata.id" options="$ctrl.pickupListOptions"></pickup-list>
-  </md-content>
+  </div>
 </div>

--- a/client/app/components/home/home.html
+++ b/client/app/components/home/home.html
@@ -1,8 +1,8 @@
-<md-content class="md-whiteframe-2dp" layout-padding>
+<div class="md-whiteframe-2dp" layout-padding>
   <div>
     <div layout="row" layout-align="space-around">
       <md-progress-circular md-mode="indeterminate"></md-progress-circular>
     </div>
     <center translate="HOME.REDIRECT"></center>
   </div>
-</md-content>
+</div>

--- a/client/app/components/userDetail/userDetail.html
+++ b/client/app/components/userDetail/userDetail.html
@@ -19,7 +19,7 @@
       </span>
     </div>
   </md-toolbar>
-  <md-content>
+  <div class="content">
     <div ng-if="!$ctrl.editEnabled">
       <h3><i class="fa fa-envelope-o" aria-hidden="true"></i> {{ $ctrl.userdata.email }}</h3>
       <expandable-panel content="$ctrl.userdata.description" markdown="true" collapse="1000"></expandable-panel>
@@ -60,7 +60,7 @@
       </div>
 
     </form>
-  </md-content>
-</div>          
+  </div>
+</div>
   <div flex></div>
 </div>

--- a/client/app/components/userDetail/userDetail.styl
+++ b/client/app/components/userDetail/userDetail.styl
@@ -3,5 +3,5 @@
     max-width: 60em
     .fa
         margin-right: 1em
-    md-content
+    div.content
         padding: 20px


### PR DESCRIPTION
It would only be suitable for locations where we want to have multiple scrollbars (e.g. in dialogs, where the outer scrollbar is disabled). I quickly checked and the site worked in the same way with this change. I think a md-content without a defined height is basically the same as a div.

Reference: https://material.angularjs.org/latest/api/directive/mdContent

Together with #312 it would also mean that we should only use md-content in md-dialog, if necessary. @D0nPiano what do you think about this?