### PR TITLE
localize: set language header to frontend language

### DIFF
--- a/client/app/app.localizeConfig.js
+++ b/client/app/app.localizeConfig.js
@@ -7,7 +7,7 @@ import localeEO from "./locales/locale-eo.json";
 import localeIT from "./locales/locale-it.json";
 import localeRU from "./locales/locale-ru.json";
 
-let AppLocalize = ($translateProvider) => {
+let AppLocalize = ($translateProvider, $httpProvider) => {
   "ngInject";
   $translateProvider
   .useCookieStorage()
@@ -30,6 +30,16 @@ let AppLocalize = ($translateProvider) => {
     "ru_*": "ru"
   })
   .determinePreferredLanguage();
+
+  $httpProvider.interceptors.push(($translate) => {
+    "ngInject";
+    return {
+      "request": (config) => {
+        config.headers["Accept-Language"] = $translate.use();
+        return config;
+      }
+    };
+  });
 };
 
 export default AppLocalize;

--- a/client/app/services/geocoding/geocoding.service.js
+++ b/client/app/services/geocoding/geocoding.service.js
@@ -1,16 +1,14 @@
 class GeocodingService {
-  constructor($http, $translate) {
+  constructor($http) {
     "ngInject";
     Object.assign(this, {
-      $http,
-      $translate
+      $http
     });
   }
 
-  lookupAddress(address, lang = false) {
-    if (!lang) lang = this.$translate.use();
+  lookupAddress(address) {
     return this.$http.get("https://nominatim.openstreetmap.org/search", {
-      params: { "accept-language": lang, format: "json", q: address },
+      params: { format: "json", q: address },
       ignoreLoadingBar: true
     }).then((res) => {
       return res.data.map((p) => {

--- a/client/app/services/geocoding/geocoding.spec.js
+++ b/client/app/services/geocoding/geocoding.spec.js
@@ -1,5 +1,4 @@
 import GeocodingModule from "./geocoding";
-import translate from "angular-translate";
 
 const { module } = angular.mock;
 
@@ -7,7 +6,6 @@ describe("geocoding", () => {
   let $httpBackend, Geocoding;
   beforeEach(() => {
     module(GeocodingModule);
-    module(translate);
   });
 
   let $log;
@@ -35,9 +33,9 @@ describe("geocoding", () => {
       lon: "2.99",
       display_name: "something" // eslint-disable-line
     }];
-    $httpBackend.expectGET("https://nominatim.openstreetmap.org/search?accept-language=en&format=json&q=enter_some")
+    $httpBackend.expectGET("https://nominatim.openstreetmap.org/search?format=json&q=enter_some")
       .respond(latlonname);
-    expect(Geocoding.lookupAddress("enter_some", "en"))
+    expect(Geocoding.lookupAddress("enter_some"))
       .to.be.fulfilled.and
       .to.eventually.deep.equal([
         {


### PR DESCRIPTION
Override the default Accept-Language header of the browser. Most people should already get their preferred language, but now they are able to switch, which is also easier for testing.

Benefits:

- translated responses from the backend can be used directly in the frontend
- mails triggered by frontend requests will get sent out in the appropriate language
- no need to set accept-language for Nominatim

In future, we also should store the selected language per user (backend).