### PR TITLE
Use services to manage current group and stores

### DIFF
--- a/client/app/components/group/_groupEditCreateForm/groupEditCreateForm.controller.js
+++ b/client/app/components/group/_groupEditCreateForm/groupEditCreateForm.controller.js
@@ -1,10 +1,11 @@
 import jstz from "jstimezonedetect";
 
 class GroupEditCreateFormController {
-  constructor(Geocoding) {
+  constructor(Geocoding, CurrentGroup) {
     "ngInject";
     Object.assign(this, {
       Geocoding,
+      CurrentGroup,
       mapCenter: {},
       mapDefaults: {
         scrollWheelZoom: false,
@@ -31,7 +32,11 @@ class GroupEditCreateFormController {
     // set locals to evaluate against in the parent expression
     // data="parent_submit(data)" takes the locals.data object
     let locals = { data: this.data };
-    this.onSubmit(locals).catch((err) => {
+    this.onSubmit(locals).then((data) => {
+      this.CurrentGroup.set(data);
+      return data;
+    })
+    .catch((err) => {
       Object.assign(this, {
         saving: false,
         error: err.data

--- a/client/app/components/group/_groupEditCreateForm/groupEditCreateForm.js
+++ b/client/app/components/group/_groupEditCreateForm/groupEditCreateForm.js
@@ -1,6 +1,7 @@
 import angular from "angular";
 import uiRouter from "angular-ui-router";
 import groupEditCreateFormComponent from "./groupEditCreateForm.component";
+import GroupService from "../../../services/group/group";
 import Geocoding from "../../../services/geocoding/geocoding";
 import markdownInput from "../../_markdownInput/markdownInput";
 import "leaflet";
@@ -10,6 +11,7 @@ import "leaflet/dist/leaflet.css"; // looks in node_modules
 let groupEditCreateFormModule = angular.module("groupEditCreateForm", [
   uiRouter,
   Geocoding,
+  GroupService,
   markdownInput,
   "ui-leaflet"
 ])

--- a/client/app/components/group/_groupEditCreateForm/groupEditCreateForm.spec.js
+++ b/client/app/components/group/_groupEditCreateForm/groupEditCreateForm.spec.js
@@ -27,10 +27,12 @@ describe("GroupEditCreateForm", () => {
   });
 
   describe("Controller", () => {
-    let $componentController, Geocoding;
+    let $componentController, Geocoding, $q, $rootScope;
     beforeEach(inject(($injector) => {
       $componentController = $injector.get("$componentController");
       Geocoding = $injector.get("Geocoding");
+      $q = $injector.get("$q");
+      $rootScope = $injector.get("$rootScope");
     }));
 
     it("initializes from binding", () => {
@@ -54,10 +56,9 @@ describe("GroupEditCreateForm", () => {
     it("submits data with error", () => {
       let $ctrl = $componentController("groupEditCreateForm", {});
       let err = { data: "err" };
-      $ctrl.onSubmit = () => {
-        return { catch: (fn) => fn(err) };
-      };
+      $ctrl.onSubmit = () => $q.reject(err);
       $ctrl.submit();
+      $rootScope.$apply();
       expect($ctrl.error).to.be.equal("err");
     });
 

--- a/client/app/components/group/_storeList/storeList.controller.js
+++ b/client/app/components/group/_storeList/storeList.controller.js
@@ -1,8 +1,10 @@
 class StoreListController {
-  constructor(Store, $state, $document, $mdMedia) {
+  constructor(Store, $state, $document, $mdMedia, CurrentStores) {
     "ngInject";
     Object.assign(this, {
       Store,
+      CurrentStores,
+      storeList: CurrentStores.list,
       $state,
       $document,
       $mdMedia,
@@ -12,7 +14,7 @@ class StoreListController {
 
   $onChanges(changes) {
     if (changes.groupId && angular.isDefined(changes.groupId.currentValue)) {
-      this.Store.listByGroupId(changes.groupId.currentValue).then((data) => this.storeList = data);
+      this.Store.listByGroupId(changes.groupId.currentValue).then((data) => this.CurrentStores.set(data));
     }
   }
 

--- a/client/app/components/group/_storeList/storeList.spec.js
+++ b/client/app/components/group/_storeList/storeList.spec.js
@@ -39,7 +39,7 @@ describe("StoreList", () => {
 
     it("gets store data", () => {
       $httpBackend.expectGET("/api/stores/?group=67").respond([storeOne]);
-      expect($ctrl.storeList).to.be.undefined;
+      expect($ctrl.storeList).to.deep.equal([]);
       $scope.groupId = 67;
       $scope.$apply();
       expect($ctrl.groupId).to.equal(67);

--- a/client/app/components/group/createGroup/createGroup.controller.js
+++ b/client/app/components/group/createGroup/createGroup.controller.js
@@ -10,6 +10,7 @@ class CreateGroupController {
   createGroup(data) {
     return this.GroupService.create(data).then((data) => {
       this.$state.go("group", { groupId: data.id });
+      return data;
     });
   }
 }

--- a/client/app/components/group/group.js
+++ b/client/app/components/group/group.js
@@ -31,10 +31,12 @@ let groupPageModule = angular.module("group", [
       redirectTo: "group.groupDetail.pickups",
       component: "group",
       resolve: {
-        groupData: ($state, GroupService, CurrentGroup, $stateParams) => {
+        groupData: (CurrentGroup) => {
+          return CurrentGroup.value;
+        },
+        groupDataResolve: ($state, GroupService, CurrentGroup, $stateParams) => {
           return GroupService.get($stateParams.groupId).then((group) => {
             CurrentGroup.set(group);
-            $state.groupData = group;
             return group;
           });
         }

--- a/client/app/components/group/groupDetail/description/description.controller.js
+++ b/client/app/components/group/groupDetail/description/description.controller.js
@@ -1,8 +1,8 @@
 class DescriptionController {
-  constructor($state) {
+  constructor(CurrentGroup) {
     "ngInject";
     Object.assign(this, {
-      groupData: $state.groupData
+      groupData: CurrentGroup.value
     });
   }
 }

--- a/client/app/components/group/groupDetail/description/description.js
+++ b/client/app/components/group/groupDetail/description/description.js
@@ -2,11 +2,13 @@ import angular from "angular";
 import uiRouter from "angular-ui-router";
 import ngMaterial from "angular-material";
 import expandablePanel from "../../../_expandablePanel/expandablePanel";
+import GroupService from "../../../../services/group/group";
 import descriptionComponent from "./description.component";
 
 let descriptionModule = angular.module("description", [
   uiRouter,
   ngMaterial,
+  GroupService,
   expandablePanel
 ])
 

--- a/client/app/components/group/groupDetail/groupDetail.controller.js
+++ b/client/app/components/group/groupDetail/groupDetail.controller.js
@@ -7,7 +7,7 @@ class GroupDetailController {
       $document,
       $mdDialog,
       CurrentGroup,
-      groupData: $state.groupData,
+      groupData: CurrentGroup.value,
       $mdMedia
     });
 

--- a/client/app/components/group/groupDetail/members/members.controller.js
+++ b/client/app/components/group/groupDetail/members/members.controller.js
@@ -1,8 +1,8 @@
 class MembersController {
-  constructor($state) {
+  constructor(CurrentGroup) {
     "ngInject";
     Object.assign(this, {
-      groupData: $state.groupData
+      groupData: CurrentGroup.value
     });
   }
 }

--- a/client/app/components/group/groupDetail/members/members.js
+++ b/client/app/components/group/groupDetail/members/members.js
@@ -1,10 +1,12 @@
 import angular from "angular";
 import uiRouter from "angular-ui-router";
 import userList from "./_userList/userList";
+import GroupService from "../../../../services/group/group";
 import membersComponent from "./members.component";
 
 let MembersModule = angular.module("members", [
   uiRouter,
+  GroupService,
   userList
 ])
 

--- a/client/app/components/group/groupEdit/groupEdit.controller.js
+++ b/client/app/components/group/groupEdit/groupEdit.controller.js
@@ -1,16 +1,17 @@
 class GroupEditController {
-  constructor($state, GroupService) {
+  constructor($state, GroupService, CurrentGroup) {
     "ngInject";
     Object.assign(this, {
       $state,
-      GroupService
+      GroupService,
+      data: angular.copy(CurrentGroup.value)
     });
   }
 
   submit(data) {
     return this.GroupService.save(data).then((data) => {
-      this.$state.groupData = data;
       this.$state.go("^");
+      return data;
     });
   }
 }

--- a/client/app/components/group/groupEdit/groupEdit.html
+++ b/client/app/components/group/groupEdit/groupEdit.html
@@ -8,6 +8,6 @@
 </md-toolbar>
 <div layout="column">
 <group-edit-create-form
-  data="$ctrl.$state.groupData"
+  data="$ctrl.data"
   on-submit="$ctrl.submit(data)">
 </group-edit-create-form>

--- a/client/app/components/group/store/_storeEditCreateForm/storeEditCreateForm.js
+++ b/client/app/components/group/store/_storeEditCreateForm/storeEditCreateForm.js
@@ -2,6 +2,7 @@ import angular from "angular";
 import uiRouter from "angular-ui-router";
 import storeEditCreateFormComponent from "./storeEditCreateForm.component";
 import Geocoding from "../../../../services/geocoding/geocoding";
+import StoreService from "../../../../services/store/store";
 import markdownInput from "../../../_markdownInput/markdownInput";
 import "leaflet";
 import "ui-leaflet";
@@ -10,6 +11,7 @@ import "leaflet/dist/leaflet.css"; // looks in node_modules
 let storeEditCreateFormModule = angular.module("storeEditCreateForm", [
   uiRouter,
   Geocoding,
+  StoreService,
   markdownInput,
   "ui-leaflet"
 ])

--- a/client/app/components/group/store/_storeEditCreateForm/storeEditCreateForm.spec.js
+++ b/client/app/components/group/store/_storeEditCreateForm/storeEditCreateForm.spec.js
@@ -27,10 +27,12 @@ describe("StoreEditCreateForm", () => {
 
 
   describe("Controller", () => {
-    let $componentController, Geocoding;
+    let $componentController, Geocoding, $q, $rootScope;
     beforeEach(inject(($injector) => {
       $componentController = $injector.get("$componentController");
       Geocoding = $injector.get("Geocoding");
+      $q = $injector.get("$q");
+      $rootScope = $injector.get("$rootScope");
     }));
 
     it("initializes from binding", () => {
@@ -54,10 +56,9 @@ describe("StoreEditCreateForm", () => {
     it("submits data with error", () => {
       let $ctrl = $componentController("storeEditCreateForm", {});
       let err = { data: "err" };
-      $ctrl.onSubmit = () => {
-        return { catch: (fn) => fn(err) };
-      };
+      $ctrl.onSubmit = () => $q.reject(err);
       $ctrl.submit();
+      $rootScope.$apply();
       expect($ctrl.error).to.be.equal("err");
     });
 

--- a/client/app/components/group/store/storeCreate/storeCreate.controller.js
+++ b/client/app/components/group/store/storeCreate/storeCreate.controller.js
@@ -1,8 +1,9 @@
 class StoreCreateController {
-  constructor(Store, $state) {
+  constructor(Store, CurrentStores, $state) {
     "ngInject";
     Object.assign(this, {
       Store,
+      CurrentStores,
       $state
     });
   }
@@ -10,6 +11,8 @@ class StoreCreateController {
   submit(data) {
     return this.Store.create(data).then((data) => {
       this.$state.go("^.store", { storeId: data.id });
+      this.CurrentStores.pushItem(data);
+      return data;
     });
   }
 }

--- a/client/app/components/group/store/storeEdit/storeEdit.controller.js
+++ b/client/app/components/group/store/storeEdit/storeEdit.controller.js
@@ -1,15 +1,18 @@
 class StoreEditController {
-  constructor($state, Store) {
+  constructor($state, Store, CurrentStores) {
     "ngInject";
     Object.assign(this, {
       $state,
-      Store
+      Store,
+      CurrentStores
     });
   }
 
   submit(data) {
     return this.Store.save(data).then((data) => {
       this.$state.go("group.store", { "storeId": data.id });
+      this.CurrentStores.replaceItem(data);
+      return data;
     });
   }
 }

--- a/client/app/services/store/currentStores.service.js
+++ b/client/app/services/store/currentStores.service.js
@@ -1,0 +1,38 @@
+/**
+  Stores an object of stores (e.g. in the current group)
+
+  Uses `angular.copy()` so you can bind the list to your
+  controller and it will keep updated. e.g.:
+
+    `this.storeList = CurrentStores.list`
+
+*/
+export default class CurrentStores {
+
+  constructor() {
+    Object.assign(this, {
+      list: []
+    });
+  }
+
+  set(list) {
+    angular.copy(list, this.list);
+    return this.list;
+  }
+
+  pushItem(item) {
+    this.list.push(item);
+    return item;
+  }
+
+  replaceItem(item) {
+    let i = this.list.findIndex((e) => e.id === item.id);
+    this.list[i] = item;
+    return item;
+  }
+
+  clear() {
+    angular.copy([], this.list);
+  }
+
+}

--- a/client/app/services/store/currentStores.spec.js
+++ b/client/app/services/store/currentStores.spec.js
@@ -1,0 +1,58 @@
+import StoreModule from "./store";
+
+const { module } = angular.mock;
+
+describe("CurrentStores service", () => {
+  beforeEach(module(StoreModule));
+
+  let $log;
+  beforeEach(inject(($injector) => {
+    $log = $injector.get("$log");
+    $log.reset();
+  }));
+  afterEach(() => {
+    $log.assertEmpty();
+  });
+
+  let CurrentStores;
+
+  beforeEach(inject(($injector) => {
+    CurrentStores = $injector.get("CurrentStores");
+  }));
+
+  it("starts with an empty empty", () => {
+    expect(CurrentStores.list).to.deep.equal([]);
+  });
+
+  it("can be set", () => {
+    let newList = [{ id: 5, name: "my store" }];
+    CurrentStores.set(newList);
+    expect(CurrentStores.list).to.deep.equal(newList);
+  });
+
+  it("can be pushed", () => {
+    let item = { id: 6, name: "my new store" };
+    CurrentStores.pushItem(item);
+    expect(CurrentStores.list).to.deep.equal([item]);
+  });
+
+  it("can be replaced", () => {
+    CurrentStores.set([{ id: 6, name: "my new store" }]);
+    let item = { id: 6, name: "changed the name" };
+    CurrentStores.replaceItem(item);
+    expect(CurrentStores.list).to.deep.equal([item]);
+  });
+
+  it("can be cleared", () => {
+    CurrentStores.set([{ some: "data" }]);
+    CurrentStores.clear();
+    expect(CurrentStores.list).to.deep.equal([]);
+  });
+
+  it("copies properties from stores during set", () => {
+    let list = CurrentStores.list;
+    CurrentStores.set([{ some: "data" }]);
+    expect(CurrentStores.list).to.equal(list);
+  });
+
+});

--- a/client/app/services/store/store.js
+++ b/client/app/services/store/store.js
@@ -1,8 +1,11 @@
 import Store from "./store.service";
+import CurrentStores from "./currentStores.service";
 
 let storeModule = angular.module("Store", [])
 
 .service("Store", Store)
+
+.service("CurrentStores", CurrentStores)
 
 .name;
 


### PR DESCRIPTION
I rewrote some components to use the CurrentGroup service and introduced a new CurrentStores service.

This fixes the problem that the group name was not in sync throughout the page after editing the store. Also, the store list could get out-of-date after edit or create operations.

Please use those services extensively in future ;)

