### PR TITLE
Script for checking usage of translation key's

### DIFF
--- a/scripts/localeDiff.sh
+++ b/scripts/localeDiff.sh
@@ -1,0 +1,18 @@
+SCRIPT=$(cat <<-END
+    const locales = require('./client/app/locales/locale-en.json');
+    function print(prefix, obj) {
+      for(let key in obj) {
+        if(obj[key] instanceof Object) {
+          print(prefix+key+'.', obj[key]);
+        } else {
+          console.log(prefix+key);
+        }
+      }
+    }
+    print('', locales);
+END
+)
+echo $SCRIPT | node | sort > /tmp/locale_current
+grep -REoh "translate=\".*?\"" client | sed 's/translate="\([^"]*\)"/\1/p' | grep -v \{\{ | sort -u  > /tmp/locale_inuse
+
+diff /tmp/locale_current /tmp/locale_inuse

--- a/scripts/localeDiff.sh
+++ b/scripts/localeDiff.sh
@@ -13,6 +13,11 @@ SCRIPT=$(cat <<-END
 END
 )
 echo $SCRIPT | node | sort > /tmp/locale_current
-grep -REoh "translate=\"[^\"]*?\"" client | sed 's/translate="\([^"]*\)"/\1/p' | grep -v \{\{ | sort -u  > /tmp/locale_inuse
+
+grep -REoh "(translate=\"[^\"]*?\"|\\\$translate\(\"[^\"]*?\"|(\"|')[^\"\']+(\"|')[ ]*\|[ ]*translate)" client | \
+  grep -Eo "(\"|')[^\"\']+(\"|')" | \
+  cut -c 2- | rev | cut -c 2- | rev | \
+  grep -v "\{" | \
+  sort -u > /tmp/locale_inuse
 
 diff /tmp/locale_current /tmp/locale_inuse

--- a/scripts/localeDiff.sh
+++ b/scripts/localeDiff.sh
@@ -13,6 +13,6 @@ SCRIPT=$(cat <<-END
 END
 )
 echo $SCRIPT | node | sort > /tmp/locale_current
-grep -REoh "translate=\".*?\"" client | sed 's/translate="\([^"]*\)"/\1/p' | grep -v \{\{ | sort -u  > /tmp/locale_inuse
+grep -REoh "translate=\"[^\"]*?\"" client | sed 's/translate="\([^"]*\)"/\1/p' | grep -v \{\{ | sort -u  > /tmp/locale_inuse
 
 diff /tmp/locale_current /tmp/locale_inuse


### PR DESCRIPTION
closes #334 

collects all usages of translation strings in following formats
`translate="..."`
`$translate("...")`
`"..." | translate`
`'...' | translate`

### current output
```diff
19,21d18
< CREATESTORE.ADDRESS
< CREATESTORE.DESCRIPTION
< CREATESTORE.NAME
33d29
< GROUP.DESCRIPTION_VERBOSE
79d74
< PICKUPLIST.NONE
90d84
< STOREEDIT.DESCRIPTION
```
