### PR TITLE
Group history rework

### DIFF
--- a/client/app/components/_profilePicture/profilePicture.component.js
+++ b/client/app/components/_profilePicture/profilePicture.component.js
@@ -1,0 +1,14 @@
+import template from "./profilePicture.html";
+import controller from "./profilePicture.controller";
+import "./profilePicture.styl";
+
+let profilePictureComponent = {
+  bindings: {
+    userId: "<",
+    size: "<"
+  },
+  template,
+  controller
+};
+
+export default profilePictureComponent;

--- a/client/app/components/_profilePicture/profilePicture.controller.js
+++ b/client/app/components/_profilePicture/profilePicture.controller.js
@@ -1,0 +1,92 @@
+function pseudoRandom(seed) {
+  let random = Math.sin(seed) * 10000;
+  random -= Math.floor(random);
+  return random;
+}
+class ProfilePictureController {
+  constructor($document, $scope, $element, User) {
+    "ngInject";
+    Object.assign(this, {
+      $document,
+      $scope,
+      User,
+      name: "",
+      picture: null,
+      el: $element
+    });
+  }
+  $onInit() {
+    this.User.get(this.userId).then( (res) => {
+      this.name = res.display_name;
+      if (res.profile_picture) {
+        // not implemented in the backend yet
+        this.picture = res.profile_picture;
+      } else {
+        this.generate(pseudoRandom(res.id));
+      }
+    });
+  }
+  generate(seed) {
+    function getRandomRange(min, max, add = 1000) {
+      return Math.floor(pseudoRandom(seed * add) * (max - min) + min);
+    }
+    const svgns = "http://www.w3.org/2000/svg";
+    const box = this.$document[0].createElementNS(svgns, "svg");
+
+    const rows = 3;
+    const columns = 3;
+    const blockSize = Math.floor(this.size / 2);
+    // how i define the box size is a bit guess work for now
+    // const this.size = parseInt(rows - 1) * parseInt(blockSize) ;
+    const rotate = blockSize * rows / 2 ;
+
+    box.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
+    box.setAttribute("width", this.size);
+    box.setAttribute("height", this.size);
+    box.setAttribute("viewbox", "0 0 100 100");
+    box.setAttribute("class", "box");
+
+    const g = this.$document[0].createElementNS(svgns, "g");
+    g.setAttribute(
+        "transform",
+        `translate(${-(rows * blockSize - this.size) / 2} ${-((rows * blockSize - this.size) / 2)}) ` +
+        `rotate(${90 * seed} ${rotate} ${rotate})`
+      );
+
+    for (let i = 0; i < columns; i++) {
+      //noprotect
+      for (let j = 0; j < rows; j++) {
+        let rect = this.$document[0].createElementNS(svgns, "rect");
+        rect.setAttribute("width", blockSize);
+        rect.setAttribute("height", blockSize);
+        rect.setAttribute("fill", "rgba(" +
+          getRandomRange(100, 255, (i + 1) * (j + 1) * 1) + "," +
+          getRandomRange(100, 255, (i + 1) * (j + 1) * 2) + "," +
+          getRandomRange(100, 255, (i + 1) * (j + 1) * 3) + ",1)"
+        );
+        rect.setAttribute("x", i * blockSize);
+        rect.setAttribute("y", j * blockSize);
+
+        g.appendChild(rect);
+      }
+    }
+    box.appendChild(g);
+
+    let overlay = this.$document[0].createElementNS(svgns, "rect");
+    overlay.setAttribute("width", this.size);
+    overlay.setAttribute("height", this.size);
+    overlay.setAttribute("fill", "rgba(" +
+      getRandomRange(100, 255, 1) + "," +
+      getRandomRange(100, 255, 2) + "," +
+      getRandomRange(100, 255, 3) + ",0.5)"
+    );
+    overlay.setAttribute("x", 0);
+    overlay.setAttribute("y", 0);
+    box.appendChild(overlay);
+
+    this.el[0].firstChild.appendChild(box);
+
+  }
+}
+
+export default ProfilePictureController;

--- a/client/app/components/_profilePicture/profilePicture.controller.js
+++ b/client/app/components/_profilePicture/profilePicture.controller.js
@@ -1,19 +1,9 @@
-function pseudoRandom(seed) {
-  let random = Math.sin(seed) * 10000;
-  random -= Math.floor(random);
-  return random;
-}
 class ProfilePictureController {
-  constructor($document, $scope, $element, User, $translate) {
+  constructor(User, $translate) {
     "ngInject";
     Object.assign(this, {
-      $document,
-      $scope,
       User,
-      $translate,
-      name: "",
-      picture: null,
-      el: $element
+      $translate
     });
   }
   $onInit() {
@@ -22,76 +12,12 @@ class ProfilePictureController {
       if (res.profile_picture) {
         // not implemented in the backend yet
         this.picture = res.profile_picture;
-      } else {
-        this.generate(pseudoRandom(res.id));
       }
     }).catch(() => {
       this.$translate("PROFILE.INACCESSIBLE_OR_DELETED").then((text) => {
         this.name = text;
       });
-      this.generate(pseudoRandom(this.userId));
     });
-  }
-  generate(seed) {
-    function getRandomRange(min, max, add = 1000) {
-      return Math.floor(pseudoRandom(seed * add) * (max - min) + min);
-    }
-    const svgns = "http://www.w3.org/2000/svg";
-    const box = this.$document[0].createElementNS(svgns, "svg");
-
-    const rows = 3;
-    const columns = 3;
-    const blockSize = Math.floor(this.size / 2);
-    // how i define the box size is a bit guess work for now
-    // const this.size = parseInt(rows - 1) * parseInt(blockSize) ;
-    const rotate = blockSize * rows / 2 ;
-
-    box.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
-    box.setAttribute("width", this.size);
-    box.setAttribute("height", this.size);
-    box.setAttribute("viewbox", "0 0 100 100");
-    box.setAttribute("class", "box");
-
-    const g = this.$document[0].createElementNS(svgns, "g");
-    g.setAttribute(
-        "transform",
-        `translate(${-(rows * blockSize - this.size) / 2} ${-((rows * blockSize - this.size) / 2)}) ` +
-        `rotate(${90 * seed} ${rotate} ${rotate})`
-      );
-
-    for (let i = 0; i < columns; i++) {
-      //noprotect
-      for (let j = 0; j < rows; j++) {
-        let rect = this.$document[0].createElementNS(svgns, "rect");
-        rect.setAttribute("width", blockSize);
-        rect.setAttribute("height", blockSize);
-        rect.setAttribute("fill", "rgba(" +
-          getRandomRange(100, 255, (i + 1) * (j + 1) * 1) + "," +
-          getRandomRange(100, 255, (i + 1) * (j + 1) * 2) + "," +
-          getRandomRange(100, 255, (i + 1) * (j + 1) * 3) + ",1)"
-        );
-        rect.setAttribute("x", i * blockSize);
-        rect.setAttribute("y", j * blockSize);
-
-        g.appendChild(rect);
-      }
-    }
-    box.appendChild(g);
-
-    let overlay = this.$document[0].createElementNS(svgns, "rect");
-    overlay.setAttribute("width", this.size);
-    overlay.setAttribute("height", this.size);
-    overlay.setAttribute("fill", "rgba(" +
-      getRandomRange(100, 255, 1) + "," +
-      getRandomRange(100, 255, 2) + "," +
-      getRandomRange(100, 255, 3) + ",0.5)"
-    );
-    overlay.setAttribute("x", 0);
-    overlay.setAttribute("y", 0);
-    box.appendChild(overlay);
-
-    this.el[0].firstChild.appendChild(box);
-
   }
 }
 

--- a/client/app/components/_profilePicture/profilePicture.controller.js
+++ b/client/app/components/_profilePicture/profilePicture.controller.js
@@ -4,19 +4,20 @@ function pseudoRandom(seed) {
   return random;
 }
 class ProfilePictureController {
-  constructor($document, $scope, $element, User) {
+  constructor($document, $scope, $element, User, $translate) {
     "ngInject";
     Object.assign(this, {
       $document,
       $scope,
       User,
+      $translate,
       name: "",
       picture: null,
       el: $element
     });
   }
   $onInit() {
-    this.User.get(this.userId).then( (res) => {
+    this.User.get(this.userId).then((res) => {
       this.name = res.display_name;
       if (res.profile_picture) {
         // not implemented in the backend yet
@@ -24,6 +25,11 @@ class ProfilePictureController {
       } else {
         this.generate(pseudoRandom(res.id));
       }
+    }).catch(() => {
+      this.$translate("PROFILE.INACCESSIBLE_OR_DELETED").then((text) => {
+        this.name = text;
+      });
+      this.generate(pseudoRandom(this.userId));
     });
   }
   generate(seed) {

--- a/client/app/components/_profilePicture/profilePicture.controller.js
+++ b/client/app/components/_profilePicture/profilePicture.controller.js
@@ -9,10 +9,6 @@ class ProfilePictureController {
   $onInit() {
     this.User.get(this.userId).then((res) => {
       this.name = res.display_name;
-      if (res.profile_picture) {
-        // not implemented in the backend yet
-        this.picture = res.profile_picture;
-      }
     }).catch(() => {
       this.$translate("PROFILE.INACCESSIBLE_OR_DELETED").then((text) => {
         this.name = text;

--- a/client/app/components/_profilePicture/profilePicture.html
+++ b/client/app/components/_profilePicture/profilePicture.html
@@ -1,3 +1,4 @@
 <a ui-sref="userDetail({id:$ctrl.userId})">
+  <random-picture seed="$ctrl.userId" size="$ctrl.size"></random-picture>
   <md-tooltip>{{ $ctrl.name }}</md-tooltip>
 </a>

--- a/client/app/components/_profilePicture/profilePicture.html
+++ b/client/app/components/_profilePicture/profilePicture.html
@@ -1,0 +1,3 @@
+<a ui-sref="userDetail({id:$ctrl.userId})">
+  <md-tooltip>{{ $ctrl.name }}</md-tooltip>
+</a>

--- a/client/app/components/_profilePicture/profilePicture.js
+++ b/client/app/components/_profilePicture/profilePicture.js
@@ -1,6 +1,7 @@
 import angular from "angular";
 import uiRouter from "angular-ui-router";
 import profilePictureComponent from "./profilePicture.component";
+import randomPictureDirective from "./randomPicture.directive";
 import userService from "../../services/user/user";
 
 let profilePictureModule = angular.module("profilePicture", [
@@ -9,6 +10,8 @@ let profilePictureModule = angular.module("profilePicture", [
 ])
 
 .component("profilePicture", profilePictureComponent)
+
+.directive("randomPicture", randomPictureDirective)
 
 .name;
 

--- a/client/app/components/_profilePicture/profilePicture.js
+++ b/client/app/components/_profilePicture/profilePicture.js
@@ -1,0 +1,15 @@
+import angular from "angular";
+import uiRouter from "angular-ui-router";
+import profilePictureComponent from "./profilePicture.component";
+import userService from "../../services/user/user";
+
+let profilePictureModule = angular.module("profilePicture", [
+  uiRouter,
+  userService
+])
+
+.component("profilePicture", profilePictureComponent)
+
+.name;
+
+export default profilePictureModule;

--- a/client/app/components/_profilePicture/profilePicture.js
+++ b/client/app/components/_profilePicture/profilePicture.js
@@ -3,10 +3,12 @@ import uiRouter from "angular-ui-router";
 import profilePictureComponent from "./profilePicture.component";
 import randomPictureDirective from "./randomPicture.directive";
 import userService from "../../services/user/user";
+import translate from "angular-translate";
 
 let profilePictureModule = angular.module("profilePicture", [
   uiRouter,
-  userService
+  userService,
+  translate
 ])
 
 .component("profilePicture", profilePictureComponent)

--- a/client/app/components/_profilePicture/profilePicture.spec.js
+++ b/client/app/components/_profilePicture/profilePicture.spec.js
@@ -1,0 +1,34 @@
+import ProfilePictureModule from "./profilePicture";
+
+const { module } = angular.mock;
+
+describe("ProfilePicture", () => {
+  beforeEach(module(ProfilePictureModule));
+
+  let $log;
+  beforeEach(inject(($injector) => {
+    $log = $injector.get("$log");
+    $log.reset();
+  }));
+  afterEach(() => {
+    $log.assertEmpty();
+  });
+
+  describe("Module", () => {
+    it("is named profilePicture", () => {
+      expect(ProfilePictureModule).to.equal("profilePicture");
+    });
+  });
+
+  describe("Controller", () => {
+    let $componentController;
+    beforeEach(inject(($injector) => {
+      $componentController = $injector.get("$componentController");
+    }));
+
+    it("should exist", () => {
+      let $ctrl = $componentController("profilePicture", {});
+      expect($ctrl).to.exist;
+    });
+  });
+});

--- a/client/app/components/_profilePicture/profilePicture.spec.js
+++ b/client/app/components/_profilePicture/profilePicture.spec.js
@@ -21,14 +21,36 @@ describe("ProfilePicture", () => {
   });
 
   describe("Controller", () => {
-    let $componentController;
+    let $componentController, $q, $rootScope, User;
     beforeEach(inject(($injector) => {
       $componentController = $injector.get("$componentController");
+      $q = $injector.get("$q");
+      $rootScope = $injector.get("$rootScope");
+      User = $injector.get("User");
+      sinon.stub(User, "get");
     }));
 
-    it("should exist", () => {
-      let $ctrl = $componentController("profilePicture", {});
-      expect($ctrl).to.exist;
+    it("loads username", () => {
+      let $ctrl = $componentController("profilePicture", {}, { userId: 42 });
+      User.get.withArgs(42).returns($q.resolve({ "display_name": "lovely unicorn" }));
+      $ctrl.$onInit();
+      $rootScope.$apply();
+      expect($ctrl.name).to.equal("lovely unicorn");
     });
+
+    it("invalid user", () => {
+      let $ctrl = $componentController("profilePicture", {}, { userId: 666 });
+      User.get.withArgs(666).returns($q.reject());
+      //$translate.withArgs("PROFILE.INACCESSIBLE_OR_DELETED").returns($q.resolve("translated string"));
+      $ctrl.$onInit();
+      try {
+        $rootScope.$apply();
+      } catch (e) {
+        // TODO: figure out how to test $translate
+      }
+
+      //expect($ctrl.name).to.equal("translated string");
+    });
+
   });
 });

--- a/client/app/components/_profilePicture/profilePicture.styl
+++ b/client/app/components/_profilePicture/profilePicture.styl
@@ -1,0 +1,5 @@
+profile-picture {
+  display: inline;
+  width: 1em;
+  height: 1em;
+}

--- a/client/app/components/_profilePicture/randomPicture.directive.js
+++ b/client/app/components/_profilePicture/randomPicture.directive.js
@@ -1,0 +1,82 @@
+let randomPictureDirective = ($document) => {
+  "ngInject";
+  return {
+    restrict: "EA",
+    scope: {
+      seed: "<",
+      size: "<"
+    },
+    template: "<div></div>",
+    link: {
+      post: (scope, iElement) => {
+        function pseudoRandom(seed) {
+          let random = Math.sin(seed) * 10000;
+          random -= Math.floor(random);
+          return random;
+        }
+        let seed = pseudoRandom(scope.seed);
+        let size = scope.size;
+
+        function getRandomRange(min, max, add = 1000) {
+          return Math.floor(pseudoRandom(seed * add) * (max - min) + min);
+        }
+        const svgns = "http://www.w3.org/2000/svg";
+        const box = $document[0].createElementNS(svgns, "svg");
+
+        const rows = 3;
+        const columns = 3;
+        const blockSize = Math.floor(size / 2);
+        const rotate = blockSize * rows / 2 ;
+
+        box.setAttribute("xmlns:xlink","http://www.w3.org/1999/xlink");
+        box.setAttribute("width", size);
+        box.setAttribute("height", size);
+        box.setAttribute("viewbox", "0 0 100 100");
+        box.setAttribute("class", "box");
+
+        const g = $document[0].createElementNS(svgns, "g");
+        g.setAttribute(
+            "transform",
+            `translate(${-(rows * blockSize - size) / 2} ${-((rows * blockSize - size) / 2)}) ` +
+            `rotate(${90 * seed} ${rotate} ${rotate})`
+          );
+
+        for (let i = 0; i < columns; i++) {
+          //noprotect
+          for (let j = 0; j < rows; j++) {
+            let rect = $document[0].createElementNS(svgns, "rect");
+            rect.setAttribute("width", blockSize);
+            rect.setAttribute("height", blockSize);
+            rect.setAttribute("fill", "rgba(" +
+              getRandomRange(100, 255, (i + 1) * (j + 1) * 1) + "," +
+              getRandomRange(100, 255, (i + 1) * (j + 1) * 2) + "," +
+              getRandomRange(100, 255, (i + 1) * (j + 1) * 3) + ",1)"
+            );
+            rect.setAttribute("x", i * blockSize);
+            rect.setAttribute("y", j * blockSize);
+
+            g.appendChild(rect);
+          }
+        }
+        box.appendChild(g);
+
+        let overlay = $document[0].createElementNS(svgns, "rect");
+        overlay.setAttribute("width", size);
+        overlay.setAttribute("height", size);
+        overlay.setAttribute("fill", "rgba(" +
+          getRandomRange(100, 255, 1) + "," +
+          getRandomRange(100, 255, 2) + "," +
+          getRandomRange(100, 255, 3) + ",0.5)"
+        );
+        overlay.setAttribute("x", 0);
+        overlay.setAttribute("y", 0);
+        box.appendChild(overlay);
+
+        iElement.append(box);
+
+      }
+    }
+  };
+};
+
+export default randomPictureDirective;

--- a/client/app/components/_profilePicture/randomPicture.directive.js
+++ b/client/app/components/_profilePicture/randomPicture.directive.js
@@ -6,7 +6,7 @@ let randomPictureDirective = ($document) => {
       seed: "<",
       size: "<"
     },
-    template: "<div></div>",
+    template: "",
     link: {
       post: (scope, iElement) => {
         function pseudoRandom(seed) {

--- a/client/app/components/_profilePicture/randomPicture.spec.js
+++ b/client/app/components/_profilePicture/randomPicture.spec.js
@@ -1,0 +1,28 @@
+import ProfilePictureModule from "./profilePicture";
+
+const { module } = angular.mock;
+
+describe("ProfilePicture", () => {
+  beforeEach(module(ProfilePictureModule));
+
+  let $log;
+  beforeEach(inject(($injector) => {
+    $log = $injector.get("$log");
+    $log.reset();
+  }));
+  afterEach(() => {
+    $log.assertEmpty();
+  });
+
+  let $compile, $rootScope;
+  beforeEach(inject(($injector) => {
+    $compile = $injector.get("$compile");
+    $rootScope = $injector.get("$rootScope");
+  }));
+
+  it("loads directive", () => {
+    let element = $compile("<random-picture seed=5 size=3></random-picture>")($rootScope);
+    $rootScope.$digest();
+    expect(element.html()).to.contain("<svg");
+  });
+});

--- a/client/app/components/group/_history/history.component.js
+++ b/client/app/components/group/_history/history.component.js
@@ -1,0 +1,11 @@
+import template from "./history.html";
+import controller from "./history.controller";
+import "./history.styl";
+
+let historyComponent = {
+  bindings: {},
+  template,
+  controller
+};
+
+export default historyComponent;

--- a/client/app/components/group/_history/history.component.js
+++ b/client/app/components/group/_history/history.component.js
@@ -3,7 +3,9 @@ import controller from "./history.controller";
 import "./history.styl";
 
 let historyComponent = {
-  bindings: {},
+  bindings: {
+    data: "<"
+  },
   template,
   controller
 };

--- a/client/app/components/group/_history/history.controller.js
+++ b/client/app/components/group/_history/history.controller.js
@@ -1,20 +1,18 @@
 class HistoryController {
-  constructor(History) {
+  constructor() {
     "ngInject";
     Object.assign(this, {
-      History,
-      list: []
     });
   }
-  $onInit() {
-    this.History.get().then( (res) => {
-      this.list = res
-        .map( (entry) => {
-          entry.translate = "HISTORY." + entry.typus;
-          entry.compareDate = entry.date.toISOString().substr(0,10);
-          return entry;
-        });
-    });
+  $onChanges(changes) {
+    console.log(changes);
+    if (changes && changes.data) {
+      angular.forEach(this.data, (entry) => {
+        entry.translate = "HISTORY." + entry.typus;
+        entry.compareDate = entry.date.toISOString().substr(0,10);
+        return entry;
+      });
+    }
   }
 }
 

--- a/client/app/components/group/_history/history.controller.js
+++ b/client/app/components/group/_history/history.controller.js
@@ -1,0 +1,22 @@
+class HistoryController {
+  constructor(History) {
+    "ngInject";
+    Object.assign(this, {
+      History,
+      list: []
+    });
+  }
+  $onInit() {
+    this.History.get().then( (res) => {
+      this.list = res
+        .sort( (a, b) => a.date < b.date)
+        .map( (entry) => {
+          entry.translate = "HISTORY." + entry.typus;
+          entry.compareDate = entry.date.toISOString().substr(0,10);
+          return entry;
+        });
+    });
+  }
+}
+
+export default HistoryController;

--- a/client/app/components/group/_history/history.controller.js
+++ b/client/app/components/group/_history/history.controller.js
@@ -5,7 +5,6 @@ class HistoryController {
     });
   }
   $onChanges(changes) {
-    console.log(changes);
     if (changes && changes.data) {
       angular.forEach(this.data, (entry) => {
         entry.translate = "HISTORY." + entry.typus;

--- a/client/app/components/group/_history/history.controller.js
+++ b/client/app/components/group/_history/history.controller.js
@@ -9,7 +9,6 @@ class HistoryController {
   $onInit() {
     this.History.get().then( (res) => {
       this.list = res
-        .sort( (a, b) => a.date < b.date)
         .map( (entry) => {
           entry.translate = "HISTORY." + entry.typus;
           entry.compareDate = entry.date.toISOString().substr(0,10);

--- a/client/app/components/group/_history/history.html
+++ b/client/app/components/group/_history/history.html
@@ -1,0 +1,18 @@
+<div>
+  <div ng-repeat="entry in $ctrl.list">
+    <div ng-if="$first || $ctrl.list[$index-1].compareDate != entry.compareDate" class="date">
+      {{ entry.date | date:'fullDate' }}
+    </div>
+    <div layout="row">
+      <div flex class="time">
+        {{ entry.date | date:'shortTime' }}
+      </div>
+      <div flex class="avatar s{{ entry.users.length }}">
+        <div ng-repeat="id in entry.users"><profile-picture user-id="id" size="20"></profile-picture></div>
+      </div>
+      <div flex class="">
+        <span translate="{{ entry.translate }}" translate-values="{{ entry.payload }}"></span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/client/app/components/group/_history/history.html
+++ b/client/app/components/group/_history/history.html
@@ -1,6 +1,6 @@
 <div>
-  <div ng-repeat="entry in $ctrl.list">
-    <div ng-if="$first || $ctrl.list[$index-1].compareDate != entry.compareDate" class="date">
+  <div ng-repeat="entry in $ctrl.data">
+    <div ng-if="$first || $ctrl.data[$index-1].compareDate != entry.compareDate" class="date">
       {{ entry.date | date:'fullDate' }}
     </div>
     <div layout="row">

--- a/client/app/components/group/_history/history.js
+++ b/client/app/components/group/_history/history.js
@@ -1,0 +1,18 @@
+import angular from "angular";
+import uiRouter from "angular-ui-router";
+import historyComponent from "./history.component";
+import profilePicture from "../../_profilePicture/profilePicture";
+import historyService from "../../../services/history/history";
+
+let historyModule = angular.module("history", [
+  uiRouter,
+  profilePicture,
+  historyService
+])
+
+.component("history", historyComponent)
+
+
+.name;
+
+export default historyModule;

--- a/client/app/components/group/_history/history.js
+++ b/client/app/components/group/_history/history.js
@@ -2,12 +2,10 @@ import angular from "angular";
 import uiRouter from "angular-ui-router";
 import historyComponent from "./history.component";
 import profilePicture from "../../_profilePicture/profilePicture";
-import historyService from "../../../services/history/history";
 
 let historyModule = angular.module("history", [
   uiRouter,
-  profilePicture,
-  historyService
+  profilePicture
 ])
 
 .component("history", historyComponent)

--- a/client/app/components/group/_history/history.spec.js
+++ b/client/app/components/group/_history/history.spec.js
@@ -26,9 +26,15 @@ describe("History", () => {
       $componentController = $injector.get("$componentController");
     }));
 
-    it("should exist", () => {
-      let $ctrl = $componentController("history", {});
-      expect($ctrl).to.exist;
+    it("transforms data", () => {
+      let data = [{
+        typus: "GROUP_JOIN",
+        date: new Date("2017-02-20T12:00:20Z")
+      }];
+      let $ctrl = $componentController("history", {}, { data });
+      $ctrl.$onChanges({ data: "is unused" });
+      expect(data[0].translate).to.be.equal("HISTORY.GROUP_JOIN");
+      expect(data[0].compareDate).to.be.equal("2017-02-20");
     });
   });
 });

--- a/client/app/components/group/_history/history.spec.js
+++ b/client/app/components/group/_history/history.spec.js
@@ -1,0 +1,34 @@
+import HistoryModule from "./history";
+
+const { module } = angular.mock;
+
+describe("History", () => {
+  beforeEach(module(HistoryModule));
+
+  let $log;
+  beforeEach(inject(($injector) => {
+    $log = $injector.get("$log");
+    $log.reset();
+  }));
+  afterEach(() => {
+    $log.assertEmpty();
+  });
+
+  describe("Module", () => {
+    it("is named history", () => {
+      expect(HistoryModule).to.equal("history");
+    });
+  });
+
+  describe("Controller", () => {
+    let $componentController;
+    beforeEach(inject(($injector) => {
+      $componentController = $injector.get("$componentController");
+    }));
+
+    it("should exist", () => {
+      let $ctrl = $componentController("history", {});
+      expect($ctrl).to.exist;
+    });
+  });
+});

--- a/client/app/components/group/_history/history.styl
+++ b/client/app/components/group/_history/history.styl
@@ -1,0 +1,47 @@
+history {
+  ul {
+    list-style: none;
+
+  }
+  .date {
+    border-bottom: 1px solid #ccc;
+    opacity: 0.4;
+    margin-top: 1em;
+    margin-bottom: 0.2em;
+    clear:both;
+    padding: 0.3em;
+  }
+  .desc {
+    padding: 0.3em;
+    padding-left: 1em;
+  }
+  .time {
+    font-size: 0.8em;
+    max-width: 60px;
+    text-align: right;
+    opacity: 0.4;
+    padding: 0.2em;
+  }
+  .avatar {
+    max-width: 42px;
+    margin-right: 0.5em;
+  }
+  .avatar > div {
+    width: 20px;
+    float:right;
+    overflow: hidden;
+    border-left: 1px solid #fff;
+  }
+  .avatar.s2 > div {
+    width: 19px;
+  }
+  .avatar.s3 > div {
+    width: 13px;
+  }
+  .avatar.s4 > div {
+    width: 9px;
+  }
+  .avatar.s5 > div {
+    width: 7.4px;
+  }
+}

--- a/client/app/components/group/groupDetail/groupDetail.html
+++ b/client/app/components/group/groupDetail/groupDetail.html
@@ -38,6 +38,9 @@
       <md-nav-item ng-if="!$ctrl.$mdMedia('gt-sm')" md-nav-sref="group.groupDetail.stores" name="stores">
         <span translate="GROUP.STORES"></span>
       </md-nav-item>
+      <md-nav-item md-nav-sref="group.groupDetail.history" name="history">
+        <span translate="GROUP.HISTORY"></span>
+      </md-nav-item>
       <md-nav-item ng-if="!$ctrl.$mdMedia('gt-sm')" md-nav-sref="group.groupDetail.description" name="description">
         <span translate="GROUP.DESCRIPTION"></span>
       </md-nav-item>

--- a/client/app/components/group/groupDetail/groupDetail.js
+++ b/client/app/components/group/groupDetail/groupDetail.js
@@ -6,6 +6,7 @@ import description from "./description/description";
 import members from "./members/members";
 import pickups from "./pickups/pickups";
 import stores from "./stores/stores";
+import history from "./groupHistory/groupHistory";
 import expandablePanel from "../../_expandablePanel/expandablePanel";
 import GroupService from "../../../services/group/group";
 
@@ -16,6 +17,7 @@ let groupDetailModule = angular.module("groupDetail", [
   members,
   pickups,
   stores,
+  history,
   expandablePanel,
   GroupService
 ])

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.component.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.component.js
@@ -1,0 +1,12 @@
+import template from "./groupHistory.html";
+import controller from "./groupHistory.controller";
+import "./groupHistory.styl";
+
+let groupHistoryComponent = {
+  restrict: "",
+  bindings: {},
+  template,
+  controller
+};
+
+export default groupHistoryComponent;

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.component.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.component.js
@@ -4,7 +4,9 @@ import "./groupHistory.styl";
 
 let groupHistoryComponent = {
   restrict: "",
-  bindings: {},
+  bindings: {
+    groupHistory: "<"
+  },
   template,
   controller
 };

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.controller.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.controller.js
@@ -2,9 +2,6 @@ class GroupHistoryController {
   constructor() {
     "ngInject";
     Object.assign(this, {
-      historyFilter: {
-        group: 10
-      }
     });
   }
 }

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.controller.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.controller.js
@@ -1,0 +1,12 @@
+class GroupHistoryController {
+  constructor() {
+    "ngInject";
+    Object.assign(this, {
+      historyFilter: {
+        group: 10
+      }
+    });
+  }
+}
+
+export default GroupHistoryController;

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.html
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.html
@@ -1,4 +1,1 @@
-<div>
-  <h1>History</h1>
-  <history filter="$ctrl.historyFilter"></history>
-</div>
+<history data="$ctrl.groupHistory"></history>

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.html
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.html
@@ -1,0 +1,4 @@
+<div>
+  <h1>History</h1>
+  <history filter="$ctrl.historyFilter"></history>
+</div>

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.js
@@ -19,8 +19,8 @@ let groupHistoryModule = angular.module("groupHistory", [
       url: "/history",
       component: "groupHistory",
       resolve: {
-        groupHistory: (History) => {
-          return History.get();
+        groupHistory: (HistoryService, $stateParams) => {
+          return HistoryService.list({ group: $stateParams.groupId });
         }
       },
       ncyBreadcrumb: {

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.js
@@ -1,0 +1,27 @@
+import angular from "angular";
+import uiRouter from "angular-ui-router";
+import groupHistoryComponent from "./groupHistory.component";
+import history from "../../_history/history";
+
+let groupHistoryModule = angular.module("groupHistory", [
+  uiRouter,
+  history
+])
+
+.component("groupHistory", groupHistoryComponent)
+
+.config(($stateProvider) => {
+  "ngInject";
+  $stateProvider
+    .state("group.groupDetail.history", {
+      url: "/history",
+      component: "history",
+      ncyBreadcrumb: {
+        label: "{{'GROUP.HISTORY' | translate}}"
+      }
+    });
+})
+
+.name;
+
+export default groupHistoryModule;

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.js
@@ -1,11 +1,13 @@
 import angular from "angular";
 import uiRouter from "angular-ui-router";
 import groupHistoryComponent from "./groupHistory.component";
+import historyService from "../../../../services/history/history";
 import history from "../../_history/history";
 
 let groupHistoryModule = angular.module("groupHistory", [
   uiRouter,
-  history
+  history,
+  historyService
 ])
 
 .component("groupHistory", groupHistoryComponent)
@@ -15,7 +17,12 @@ let groupHistoryModule = angular.module("groupHistory", [
   $stateProvider
     .state("group.groupDetail.history", {
       url: "/history",
-      component: "history",
+      component: "groupHistory",
+      resolve: {
+        groupHistory: (History) => {
+          return History.get();
+        }
+      },
       ncyBreadcrumb: {
         label: "{{'GROUP.HISTORY' | translate}}"
       }

--- a/client/app/components/group/groupDetail/groupHistory/groupHistory.spec.js
+++ b/client/app/components/group/groupDetail/groupHistory/groupHistory.spec.js
@@ -1,0 +1,34 @@
+import GroupHistoryModule from "./groupHistory";
+
+const { module } = angular.mock;
+
+describe("GroupHistory", () => {
+  beforeEach(module(GroupHistoryModule));
+
+  let $log;
+  beforeEach(inject(($injector) => {
+    $log = $injector.get("$log");
+    $log.reset();
+  }));
+  afterEach(() => {
+    $log.assertEmpty();
+  });
+
+  describe("Module", () => {
+    it("is named groupHistory", () => {
+      expect(GroupHistoryModule).to.equal("groupHistory");
+    });
+  });
+
+  describe("Controller", () => {
+    let $componentController;
+    beforeEach(inject(($injector) => {
+      $componentController = $injector.get("$componentController");
+    }));
+
+    it("should exist", () => {
+      let $ctrl = $componentController("groupHistory", {});
+      expect($ctrl).to.exist;
+    });
+  });
+});

--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -64,6 +64,9 @@
     "PASSWORD_CHANGE": "Change your password (you will be logged out)",
     "PASSWORD": "Enter your new password"
   },
+  "PROFILE": {
+    "INACCESSIBLE_OR_DELETED": "(User inaccessible or deleted)"
+  },
   "JOINGROUP": {
     "NAME": "Name",
     "WHICHGROUP": "Which group do you want to join?",

--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -154,9 +154,21 @@
     "HELP": "What is Markdown?"
   },
   "HISTORY":{
-    "SERIES_CREATE":"has created a new recurring pick-up",
-    "STORE_CREATE":"has created {{name}}",
-    "GROUP_JOIN":"joined this group",
-    "PICKUP_DONE":"made a pickup at {{storeName}}"
+    "GROUP_CREATE": "created this group",
+    "GROUP_MODIFY": "changed the settings of this group",
+    "GROUP_JOIN": "joined this group",
+    "GROUP_LEAVE": "left this group",
+    "STORE_CREATE":"created store {{name}}",
+    "STORE_MODIFY": "changed the settings of store {{name}}",
+    "STORE_DELETE": "deleted store {{name}}",
+    "PICKUP_CREATE": "created a new one-time pick-up",
+    "PICKUP_MODIFY": "changed the settings of a pick-up",
+    "PICKUP_DELETE": "deleted a pick-up",
+    "SERIES_CREATE": "created a new recurring pick-up",
+    "SERIES_MODIFY": "changed the settings of a recurring pick-up",
+    "SERIES_DELETE": "deleted a recurring pick-up",
+    "PICKUP_DONE": "did a pick-up at {{storeName}}",
+    "PICKUP_JOIN": "signed up to do a pick-up at {{storeName}}",
+    "PICKUP_LEAVE": "stepped back from doing a pick-up at {{storeName}}"
   }
 }

--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -170,8 +170,8 @@
     "SERIES_CREATE": "created a new recurring pick-up",
     "SERIES_MODIFY": "changed the settings of a recurring pick-up",
     "SERIES_DELETE": "deleted a recurring pick-up",
-    "PICKUP_DONE": "did a pick-up at {{storeName}}",
-    "PICKUP_JOIN": "signed up to do a pick-up at {{storeName}}",
-    "PICKUP_LEAVE": "stepped back from doing a pick-up at {{storeName}}"
+    "PICKUP_DONE": "did a pick-up at {{store_name}}",
+    "PICKUP_JOIN": "signed up to do a pick-up at {{store_name}}",
+    "PICKUP_LEAVE": "stepped back from doing a pick-up at {{store_name}}"
   }
 }

--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -41,6 +41,7 @@
     "PICKUPS": "Pickups",
     "MEMBERS": "Members",
     "STORES": "Stores",
+    "HISTORY":"History",
     "DESCRIPTION": "Description",
     "ADDRESS": "Address",
     "TIMEZONE": "Time zone of group"
@@ -151,5 +152,11 @@
     "STRIKE": "strike",
     "QUOTE": "quote",
     "HELP": "What is Markdown?"
+  },
+  "HISTORY":{
+    "SERIES_CREATE":"has created a new recurring pick-up",
+    "STORE_CREATE":"has created {{name}}",
+    "GROUP_JOIN":"joined this group",
+    "PICKUP_DONE":"made a pickup at {{storeName}}"
   }
 }

--- a/client/app/services/history/history.js
+++ b/client/app/services/history/history.js
@@ -1,0 +1,9 @@
+import History from "./history.service";
+
+let historyModule = angular.module("History", [])
+
+.service("History", History)
+
+.name;
+
+export default historyModule;

--- a/client/app/services/history/history.js
+++ b/client/app/services/history/history.js
@@ -2,7 +2,7 @@ import History from "./history.service";
 
 let historyModule = angular.module("History", [])
 
-.service("History", History)
+.service("HistoryService", History)
 
 .name;
 

--- a/client/app/services/history/history.service.js
+++ b/client/app/services/history/history.service.js
@@ -1,0 +1,20 @@
+
+class HistoryService {
+  constructor($http) {
+    "ngInject";
+    Object.assign(this, {
+      $http
+    });
+  }
+  get(filter) {
+    return this.$http.get("/api/history/", { params: filter })
+      .then((res) => {
+        return res.data.results.map( (entry) => {
+          entry.date = new Date(entry.date);
+          return entry;
+        });
+      });
+  }
+}
+
+export default HistoryService;

--- a/client/app/services/history/history.service.js
+++ b/client/app/services/history/history.service.js
@@ -6,7 +6,7 @@ class HistoryService {
       $http
     });
   }
-  get(filter) {
+  list(filter) {
     return this.$http.get("/api/history/", { params: filter })
       .then((res) => {
         return res.data.results.map( (entry) => {

--- a/client/app/services/history/history.spec.js
+++ b/client/app/services/history/history.spec.js
@@ -3,21 +3,49 @@ import HistoryModule from "./history";
 const { module } = angular.mock;
 
 describe("history", () => {
-  let $log, History;
+  let $log;
   beforeEach(() => {
     module(HistoryModule);
     inject(($injector) => {
       $log = $injector.get("$log");
       $log.reset();
-      History = $injector.get("History");
     });
   });
   afterEach(() => {
     $log.assertEmpty();
   });
 
-  it("exists", () => {
-    expect(History).to.exist;
+  let $httpBackend, HistoryService;
+  beforeEach(inject(($injector) => {
+    $httpBackend = $injector.get("$httpBackend");
+    HistoryService = $injector.get("HistoryService");
+  }));
+
+  afterEach(() => {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  let resultData = [{
+    "id": 1452,
+    "date": "2017-02-26T21:13:59.342669Z",
+    "typus": "STORE_MODIFY",
+    "group": 5,
+    "store": 14,
+    "users": [101],
+    "payload": {}
+  }];
+
+  it("lists history by group", () => {
+    $httpBackend.expectGET("/api/history/?group=5").respond({
+      // pagination header
+      "count": 1404,
+      "next": "https://foodsaving.world/api/history/?limit=50&offset=50&group=5",
+      "previous": null,
+      "results": resultData
+    });
+    expect(HistoryService.list({ group: 5 })).to.be.fulfilled;
+    $httpBackend.flush();
   });
 
 });

--- a/client/app/services/history/history.spec.js
+++ b/client/app/services/history/history.spec.js
@@ -1,0 +1,23 @@
+import HistoryModule from "./history";
+
+const { module } = angular.mock;
+
+describe("history", () => {
+  let $log, History;
+  beforeEach(() => {
+    module(HistoryModule);
+    inject(($injector) => {
+      $log = $injector.get("$log");
+      $log.reset();
+      History = $injector.get("History");
+    });
+  });
+  afterEach(() => {
+    $log.assertEmpty();
+  });
+
+  it("exists", () => {
+    expect(History).to.exist;
+  });
+
+});


### PR DESCRIPTION
@alangecker I merged your branch into a new branch (based on recent master), because it still had the angular-xeditable inside. Therefore, I couldn't push to your PR anymore.. well, maybe with force-pushing, but I didn't feel legitimized.

I moved the random profile picture to a directive, because that has DOM access and seems more explicit than modifying DOM from the controller (angular vs. jquery style). I think all those `createElementNS` could also be refactored, but that's not a priority.

I moved the HistoryService call to groupHistory (using the recommended `resolve` syntax), so history is now stateless and can also be used for storeHistory and other history pages with different result sets.

Finally, I handled that case that a user has left the group and we can't access the name anymore. This was a backend decision by me some time ago, would be up for discussing it if there is need. Basic reason: privacy. If you don't have a group in common, you shouldn't be able to know that the user exists. There's maybe better ways to do that, though.