### PR TITLE
localize: removed unneeded translation strings

### DIFF
--- a/client/app/components/group/_pickupList/pickupList.html
+++ b/client/app/components/group/_pickupList/pickupList.html
@@ -58,7 +58,7 @@
     </div>
 
     <div ng-if="$ctrl.isInitialized && !$ctrl.groupedPickups.length"  layout-padding>
-      <h4 style="margin-bottom: 0"><i class="fa fa-bed"></i> <translate>PICKUPLIST.NONE</translate></h4>
+      <h4 style="margin-bottom: 0"><i class="fa fa-bed"></i> <span translate="PICKUPLIST.NONE"></span></h4>
       <small ng-if="!$ctrl.options.showCreateButton" translate="PICKUPLIST.NONE_HINT"></small>
     </div>
   </div>

--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -131,10 +131,7 @@
     "MAX_COLLECTORS": "Max Slots"
   },
   "CREATESTORE": {
-    "TITLE": "Create a new store",
-    "NAME": "Name",
-    "DESCRIPTION": "Description",
-    "ADDRESS": "Address"
+    "TITLE": "Create a new store"
   },
   "PICKUPLIST": {
     "FILTER": "Filter",


### PR DESCRIPTION
The script detects those as unneeded, but they are actually in use:

```
32d31
< GROUP.DESCRIPTION_VERBOSE
45,60d43
< HISTORY.GROUP_CREATE
< HISTORY.GROUP_JOIN
< HISTORY.GROUP_LEAVE
< HISTORY.GROUP_MODIFY
< HISTORY.PICKUP_CREATE
< HISTORY.PICKUP_DELETE
< HISTORY.PICKUP_DONE
< HISTORY.PICKUP_JOIN
< HISTORY.PICKUP_LEAVE
< HISTORY.PICKUP_MODIFY
< HISTORY.SERIES_CREATE
< HISTORY.SERIES_DELETE
< HISTORY.SERIES_MODIFY
< HISTORY.STORE_CREATE
< HISTORY.STORE_DELETE
< HISTORY.STORE_MODIFY
116d98
< STOREEDIT.DESCRIPTION
```