### PR TITLE
fix: reverse default pickup sorting

### DIFF
--- a/client/app/components/group/_pickupList/pickupList.html
+++ b/client/app/components/group/_pickupList/pickupList.html
@@ -44,7 +44,7 @@
       <md-subheader ng-show="$ctrl.options.showStickyHeaders" class="md-sticky">{{pickupDate.date| date:'fullDate'}}</md-subheader>
       <md-list>
         <pickup-list-item
-          ng-repeat="pickup in pickupDate.items| orderBy:['-date']:$ctrl.options.reversed"
+          ng-repeat="pickup in pickupDate.items | orderBy:'date':$ctrl.options.reversed"
           show-detail="$ctrl.options.showDetail"
           on-delete="$ctrl.delete(pickup)"
           parent-ctrl="$ctrl"


### PR DESCRIPTION
@D0nPiano it looks like the original code was intended. Do you remember why we had `-date` there? Does something break when we change this?

Closes #388 