### PR TITLE
Update store map by equality watching

### DIFF
--- a/client/app/components/group/_storeList/_storeMap/storeMap.component.js
+++ b/client/app/components/group/_storeList/_storeMap/storeMap.component.js
@@ -3,9 +3,7 @@ import controller from "./storeMap.controller";
 import "./storeMap.styl";
 
 let storeMapComponent = {
-  bindings: {
-    storeList: "<"
-  },
+  bindings: {},
   template,
   controller
 };

--- a/client/app/components/group/_storeList/_storeMap/storeMap.controller.js
+++ b/client/app/components/group/_storeList/_storeMap/storeMap.controller.js
@@ -1,8 +1,9 @@
 class StoreMapController {
-  constructor($scope) {
+  constructor($scope, CurrentStores) {
     "ngInject";
     Object.assign(this, {
       $scope,
+      CurrentStores,
       markers: {},
       bounds: {},
       defaults: {
@@ -13,7 +14,7 @@ class StoreMapController {
 
   $onInit() {
     // deep watching
-    this.destroy = this.$scope.$watch(() => this.storeList, () => {
+    this.destroy = this.$scope.$watch(() => this.CurrentStores.list, () => {
       this.update();
     }, true);
   }
@@ -23,7 +24,7 @@ class StoreMapController {
   }
 
   update() {
-    this.markers = this.getMarkers(this.storeList);
+    this.markers = this.getMarkers(this.CurrentStores.list);
     if (this.hasMarkers()) {
       let bounds = new L.latLngBounds(Object.values(this.markers)).pad(0.2); // eslint-disable-line
       this.bounds = {
@@ -43,7 +44,7 @@ class StoreMapController {
   getMarkers(fromArray) {
     let markers = {};
     angular.forEach(fromArray, (e) => {
-      if (e.latitude === null || e.longitude === null) return;
+      if (!e.latitude || !e.longitude) return;
       markers[e.id] = {
         lat: e.latitude,
         lng: e.longitude,

--- a/client/app/components/group/_storeList/_storeMap/storeMap.controller.js
+++ b/client/app/components/group/_storeList/_storeMap/storeMap.controller.js
@@ -1,7 +1,8 @@
 class StoreMapController {
-  constructor() {
+  constructor($scope) {
     "ngInject";
     Object.assign(this, {
+      $scope,
       markers: {},
       bounds: {},
       defaults: {
@@ -10,10 +11,15 @@ class StoreMapController {
     });
   }
 
-  $onChanges(changes) {
-    if (changes.storeList) {
+  $onInit() {
+    // deep watching
+    this.destroy = this.$scope.$watch(() => this.storeList, () => {
       this.update();
-    }
+    }, true);
+  }
+
+  $onDestroy() {
+    this.destroy();
   }
 
   update() {

--- a/client/app/components/group/_storeList/_storeMap/storeMap.js
+++ b/client/app/components/group/_storeList/_storeMap/storeMap.js
@@ -1,5 +1,6 @@
 import angular from "angular";
 import uiRouter from "angular-ui-router";
+import StoreService from "../../../../services/store/store";
 import "angular-simple-logger";
 import "leaflet";
 import "ui-leaflet";
@@ -8,6 +9,7 @@ import storeMapComponent from "./storeMap.component";
 
 let storeMapModule = angular.module("storeMap", [
   uiRouter,
+  StoreService,
   "nemLogging",
   "ui-leaflet"
 ])

--- a/client/app/components/group/_storeList/_storeMap/storeMap.spec.js
+++ b/client/app/components/group/_storeList/_storeMap/storeMap.spec.js
@@ -21,29 +21,46 @@ describe("StoreMap", () => {
   });
 
   describe("Controller", () => {
-    let $rootScope, $compile;
-    beforeEach(inject(($injector) => {
-      $rootScope = $injector.get("$rootScope");
-      $compile = $injector.get("$compile");
+    let $ctrl;
+    beforeEach(inject((_$componentController_) => {
+      $ctrl = _$componentController_("storeMap");
     }));
 
-    it("updates markers", () => {
-      let $scope = $rootScope.$new();
-      $scope.storeList = [];
-      let component = $compile("<store-map store-list='storeList'></store-map>")($scope);
-      let $ctrl = component.isolateScope().$ctrl;
-      expect($ctrl.hasMarkers()).to.be.false;
+    let anotherStore = {
+      id: 98,
+      group: 4,
+      name: "something",
+      latitude: 87, longitude: 66
+    };
 
-      $scope.storeList = [{ id: 99, group: 5, latitude: 1.99, longitude: 2.99, name: "test1" }];
-      $scope.$apply();
-      expect($ctrl.hasMarkers()).to.be.true;
-      expect($ctrl.markers).to.deep.equal({
-        99: {
-          lat: 1.99,
-          lng: 2.99,
-          message: "<a ui-sref='group.store({ storeId: 99, groupId: 5 })'>test1</a>",
-          draggable: false }
+    it("creates markers", () => {
+      expect($ctrl.getMarkers([anotherStore])).to.deep.equal({
+        "98": {
+          lat: 87, lng: 66,
+          message: "<a ui-sref='group.store({ storeId: 98, groupId: 4 })'>something</a>",
+          draggable: false
+        }
       });
     });
+
+    it("skips creating markers if no coordinate is given", () => {
+      expect($ctrl.getMarkers([{ id: 4 }])).to.deep.equal({});
+    });
+
+    it("checks if markers exist", () => {
+      expect($ctrl.hasMarkers()).to.be.false;
+      $ctrl.markers[1] = {};
+      expect($ctrl.hasMarkers()).to.be.true;
+    });
+
+    it("updates markers after adding item to CurrentStores", inject(($rootScope) => {
+      $ctrl.$onInit();
+      expect($ctrl.markers).to.deep.equal({});
+      $ctrl.CurrentStores.pushItem(anotherStore);
+      $rootScope.$apply();
+      expect($ctrl.markers[98].lat).to.equal(87);
+      $ctrl.$onDestroy();
+    }));
+
   });
 });

--- a/client/app/components/group/_storeList/storeList.controller.js
+++ b/client/app/components/group/_storeList/storeList.controller.js
@@ -1,10 +1,9 @@
 class StoreListController {
-  constructor(Store, $state, $document, $mdMedia, CurrentStores, $scope) {
+  constructor(Store, $state, $document, $mdMedia, CurrentStores) {
     "ngInject";
     Object.assign(this, {
       Store,
       CurrentStores,
-      $scope,
       storeList: CurrentStores.list,
       $state,
       $document,
@@ -12,16 +11,6 @@ class StoreListController {
       showMap: false,
       searchQuery: ""
     });
-  }
-
-  $onInit() {
-    this.deregister = this.$scope.$watch(() => this.CurrentStores.list, (list) => {
-      this.storeList = angular.copy(list);
-    }, true);
-  }
-
-  $onDestroy() {
-    this.deregister();
   }
 
   $onChanges(changes) {

--- a/client/app/components/group/_storeList/storeList.controller.js
+++ b/client/app/components/group/_storeList/storeList.controller.js
@@ -1,9 +1,10 @@
 class StoreListController {
-  constructor(Store, $state, $document, $mdMedia, CurrentStores) {
+  constructor(Store, $state, $document, $mdMedia, CurrentStores, $scope) {
     "ngInject";
     Object.assign(this, {
       Store,
       CurrentStores,
+      $scope,
       storeList: CurrentStores.list,
       $state,
       $document,
@@ -13,11 +14,20 @@ class StoreListController {
     });
   }
 
+  $onInit() {
+    this.deregister = this.$scope.$watch(() => this.CurrentStores.list, (list) => {
+      this.storeList = angular.copy(list);
+    }, true);
+  }
+
+  $onDestroy() {
+    this.deregister();
+  }
+
   $onChanges(changes) {
     if (changes.groupId && angular.isDefined(changes.groupId.currentValue)) {
       this.Store.listByGroupId(changes.groupId.currentValue).then((data) => {
         this.CurrentStores.set(data);
-        this.storeList = angular.copy(this.CurrentStores.list);
       });
     }
   }

--- a/client/app/components/group/_storeList/storeList.html
+++ b/client/app/components/group/_storeList/storeList.html
@@ -11,7 +11,7 @@
       <i style="font-size: 1.2em;" class="fa fa-map" ng-class="$ctrl.showMap ? 'fa-list' : 'fa-map'"></i>
     </md-button>
   </div>
-  <store-map ng-if="$ctrl.showMap" store-list="$ctrl.storeList"></store-map>
+  <store-map ng-if="$ctrl.showMap"></store-map>
   <md-list-item ng-if="!$ctrl.showMap" ng-repeat="store in $ctrl.storeList | filter: $ctrl.searchQuery" ui-sref-active="highlighted" ui-sref="group.store({ storeId: store.id, groupId: store.group })">
     <p>{{store.name}}</p>
   </md-list-item>


### PR DESCRIPTION
Problem: store map didn't update after an added store or address change.

I tried several patterns, but this seems to be the best compromise right now.

- $state.go with `reload: true` showed an empty map
- $doCheck needs some dirty checking, needs much code or workaround (e.d. using a version number)
- other notify patterns are quite obstructive (listeners, event broadcasting)

This should mostly work, we just need to remember this when we get into frontend performance troubles.