### PR TITLE
Include Noto font

### DIFF
--- a/client/app/app.styl
+++ b/client/app/app.styl
@@ -5,7 +5,7 @@
     font-family: 'Cabin Sketch', sans-serif
     color: #795548
     font-size: 50px
-    
+
   min-height 100%
   > md-toolbar
     height 42px
@@ -24,6 +24,15 @@
 
 body > md-content
   height 100%
+
+// Material Design Fonts
+body
+  font-family "Roboto", "Noto Sans", "Noto Sans CJK", sans-serif
+
+input, button, select, textarea
+  font-family inherit
+  font-size inherit
+  line-height inherit
 
 // the main layout panel
 .md-whiteframe-2dp

--- a/client/app/fonts/fonts.js
+++ b/client/app/fonts/fonts.js
@@ -1,2 +1,3 @@
-import "../../../node_modules/font-awesome/css/font-awesome.css";
-import "../../../node_modules/typeface-cabin-sketch/index.css";
+import "font-awesome/css/font-awesome.css";
+import "typeface-cabin-sketch/index.css";
+import "notosans-fontface/css/notosans-fontface.css";

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "markdown-it-link-attributes": "^1.0.0",
     "moment": "^2.17.1",
     "normalize.css": "^5.0.0",
+    "notosans-fontface": "^1.0.1",
     "typeface-cabin-sketch": "0.0.22",
     "ui-leaflet": "^2.0.0"
   },


### PR DESCRIPTION
The Noto font supports many scripts in the world and looks solid. It's also used by Android and recommended in Material Design: https://en.wikipedia.org/wiki/Noto_fonts

I only included the basic setup without language-specific configuration. It could need some more testing.

More on Material typopgraphy: https://material.io/guidelines/style/typography.html

Note: Material default is Roboto. I don't include Roboto because Noto supports more scripts. Roboto will still be used if it's installed (e.g. on Android)