### PR TITLE
Disable ability to select a date that is in the past

### DIFF
--- a/client/app/components/group/_pickupEditCreate/pickupEditCreate.controller.js
+++ b/client/app/components/group/_pickupEditCreate/pickupEditCreate.controller.js
@@ -21,6 +21,16 @@ class pickupEditCreateController {
       isSeries: this.data.series,
       mode: this.data.series ? "series" : "single"
     });
+    
+     setMiniDate() {
+       myDate = new Date();
+
+       this.minDate = new Date(
+       this.myDate.getFullYear(),
+       this.myDate.getMonth(),
+       this.myDate.getDate()
+       );
+     }
 
     let keys = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
     for (let i = 0; i < 7; i++) {
@@ -136,15 +146,5 @@ class pickupEditCreateController {
     this.$mdDialog.cancel();
   }
 }
-
-  noPastDateCalender() {
-  this.myDate = new Date();
-
-  this.minDate = new Date(
-    this.myDate.getFullYear(),
-    this.myDate.getMonth(),
-    this.myDate.getDate()
-  );
-  }
 
 export default pickupEditCreateController;


### PR DESCRIPTION
Added js function to only allow the current date and future dates to be selected in the pickupEditCreate folder.  Also updated the html file to use the js function.