### PR TITLE
Introduce SessionUser and fix Auth data bug

### DIFF
--- a/client/app/services/authentication/authentication.js
+++ b/client/app/services/authentication/authentication.js
@@ -1,4 +1,5 @@
 import Authentication from "./authentication.service";
+import SessionUser from "./sessionUser.service";
 import uiRouter from "@uirouter/angularjs";
 import hookProvider from "./hook.js";
 
@@ -9,6 +10,8 @@ let authenticationModule = angular.module("Authentication", [
 .provider("hook", hookProvider)
 
 .service("Authentication", Authentication)
+
+.service("SessionUser", SessionUser)
 
 .name;
 

--- a/client/app/services/authentication/authentication.service.js
+++ b/client/app/services/authentication/authentication.service.js
@@ -1,16 +1,18 @@
 class AuthenticationService {
 
-  constructor($http, $q) {
+  constructor($http, $q, SessionUser) {
     "ngInject";
     this.$http = $http;
     this.$q = $q;
-    this.data = undefined;
+    this.data = undefined;  // Deprecated, all code should use SessionUser instead
+    this.SessionUser = SessionUser;
   }
 
   login(email, password) {
     return this.$http.post("/api/auth/", { email, password })
       .then((res) => res.data)
       .then((data) => this.data = data)
+      .then((data) => this.SessionUser.set(data))
       .catch((res) => this.$q.reject(res.data));
   }
 
@@ -18,12 +20,14 @@ class AuthenticationService {
     return this.$http.get("/api/auth/status/")
       .then((res) => res.data)
       .then((data) => this.data = data)
+      .then((data) => this.SessionUser.set(data))
       .catch((res) => this.$q.reject(res.data));
   }
 
   logout() {
     return this.$http.post("/api/auth/logout/", {})
-      .then(() => this.data = undefined);
+      .then(() => this.data = undefined)
+      .then(() => this.SessionUser.clear());
   }
 }
 

--- a/client/app/services/authentication/sessionUser.service.js
+++ b/client/app/services/authentication/sessionUser.service.js
@@ -1,0 +1,40 @@
+/**
+  Makes the currently logged in user available as a service.
+
+  Uses `angular.copy()` so you can bind the value to your
+  controller and it will keep updated. e.g.:
+
+    `this.user = SessionUser.value`
+
+  Use the `loaded` promise to run code when Authentication data
+  has been loaded from the backend.
+
+    SessionUser.loaded.then((userData) => {
+      // do something with userData
+    });
+
+*/
+
+export default class sessionUser {
+
+  constructor($q) {
+    "ngInject";
+    this.deferred = $q.defer(); // eslint-disable-line
+    Object.assign(this, {
+      $q,
+      value: {},
+      loaded: this.deferred.promise
+    });
+  }
+
+  set(value) {
+    angular.copy(value, this.value);
+    this.deferred.resolve(this.value);
+    return this.value;
+  }
+
+  clear() {
+    angular.copy({}, this.value);
+  }
+
+}

--- a/client/app/services/authentication/sessionUser.spec.js
+++ b/client/app/services/authentication/sessionUser.spec.js
@@ -1,0 +1,69 @@
+import AuthenticationModule from "./authentication";
+
+const { module } = angular.mock;
+
+describe("SessionUser service", () => {
+  beforeEach(module(AuthenticationModule));
+
+  let $log;
+  beforeEach(inject(($injector) => {
+    $log = $injector.get("$log");
+    $log.reset();
+  }));
+  afterEach(() => {
+    $log.assertEmpty();
+  });
+
+  let SessionUser;
+
+  beforeEach(inject(($injector) => {
+    SessionUser = $injector.get("SessionUser");
+  }));
+
+  it("starts with an empty empty", () => {
+    expect(SessionUser.value).to.deep.equal({});
+    inject(($q, $rootScope) => {
+      let spy = sinon.spy();
+      SessionUser.loaded.then(spy);
+      $rootScope.$apply();
+      expect(spy).to.not.have.been.called;
+    });
+  });
+
+  it("can be set", () => {
+    let user = {
+      id: 1,
+      anything: "can",
+      go: "here",
+      including: ["lists", "of", "stuff"]
+    };
+    inject(($q, $rootScope) => {
+      let spy = sinon.spy();
+      SessionUser.loaded.then(spy);
+      SessionUser.set(user);
+      $rootScope.$apply();
+      expect(SessionUser.value).to.deep.equal(user);
+      expect(spy).to.have.been.calledWith(user);
+    });
+  });
+
+  it("can be cleared", () => {
+    SessionUser.set({ some: "data" });
+    SessionUser.clear();
+    expect(SessionUser.value).to.deep.equal({});
+  });
+
+  it("keeps data reference through promise callback", () => {
+    // ensures that you can bind the value from `then` and
+    // it keeps updated on subsequent calls to `set` and `clear`
+    inject(($q, $rootScope) => {
+      let data = {};
+      SessionUser.loaded.then((d) => data = d);
+      SessionUser.set({ id: 5 });
+      $rootScope.$apply();
+      SessionUser.set({ id: 6 });
+      expect(data.id).to.equal(6);
+    });
+  });
+
+});

--- a/client/app/services/group/currentGroup.service.js
+++ b/client/app/services/group/currentGroup.service.js
@@ -9,12 +9,12 @@
 */
 export default class CurrentGroup {
 
-  constructor(User, Authentication) {
+  constructor(User, SessionUser) {
     "ngInject";
     Object.assign(this, {
       value: {},
       User,
-      Authentication
+      SessionUser
     });
   }
 
@@ -29,11 +29,12 @@ export default class CurrentGroup {
   }
 
   persistCurrentGroup(groupId) {
-    let user = {
-      id: this.Authentication.data.id,
-      current_group: groupId            //eslint-disable-line
-    };
-    this.User.save(user);
+    this.SessionUser.loaded.then((user) => {
+      this.User.save({
+        id: user.id,
+        current_group: groupId  //eslint-disable-line
+      });
+    });
   }
 
 }

--- a/client/app/services/group/currentGroup.spec.js
+++ b/client/app/services/group/currentGroup.spec.js
@@ -14,14 +14,13 @@ describe("CurrentGroup service", () => {
     $log.assertEmpty();
   });
 
-  let CurrentGroup, Authentication, $httpBackend;
+  let CurrentGroup, SessionUser, $httpBackend;
 
   beforeEach(inject(($injector) => {
     CurrentGroup = $injector.get("CurrentGroup");
-    Authentication = $injector.get("Authentication");
+    SessionUser = $injector.get("SessionUser");
     $httpBackend = $injector.get("$httpBackend");
 
-    Authentication.data = { id: 1 };
     sinon.stub(CurrentGroup, "persistCurrentGroup");
   }));
 
@@ -62,8 +61,9 @@ describe("CurrentGroup service", () => {
 
   it("can persist current group", () => {
     CurrentGroup.persistCurrentGroup.restore();
+    SessionUser.set({ id: 1 });
     let user = {
-      id: Authentication.data.id,
+      id: 1,
       current_group: 4              //eslint-disable-line
     };
     $httpBackend.expectPATCH(`/api/users/${user.id}/`, user).respond(200, {});


### PR DESCRIPTION
  Makes the currently logged in user available as a service.

  Use the `loaded` promise to run code when Authentication data
  has been loaded from the backend.

```js
    SessionUser.loaded.then((userData) => {
      // do something with userData
    });
```

We should replace all usages of Authentication.data.