### PR TITLE
Improve UX when changing mail address

### DIFF
--- a/client/app/components/_topbar/_groupMenu/groupMenu.spec.js
+++ b/client/app/components/_topbar/_groupMenu/groupMenu.spec.js
@@ -32,9 +32,7 @@ describe("GroupMenu", () => {
       let $ctrl = $componentController("groupMenu", {});
       sinon.stub($ctrl.$mdDialog, "show");
       sinon.stub($ctrl.$state, "go");
-      $ctrl.$mdDialog.show.returns($q((resolve) => {
-        resolve(1337);
-      }));
+      $ctrl.$mdDialog.show.returns($q.resolve(1337));
       $ctrl.openJoinGroupDialog();
       $rootScope.$apply();
       expect($ctrl.$state.go).to.have.been.calledWith( "group", { groupId: 1337 } );
@@ -60,9 +58,7 @@ describe("GroupMenu", () => {
     it("gets data on init", () => {
       let $ctrl = $componentController("groupMenu", {});
       sinon.stub($ctrl.GroupService, "listMy");
-      $ctrl.GroupService.listMy.returns($q((resolve) => {
-        resolve([{ id: 85 }]);
-      }));
+      $ctrl.GroupService.listMy.returns($q.resolve([{ id: 85 }]));
       $ctrl.$onInit();
       $rootScope.$apply();
       expect($ctrl.GroupService.listMy).to.have.been.called;

--- a/client/app/components/_topbar/topbar.spec.js
+++ b/client/app/components/_topbar/topbar.spec.js
@@ -19,9 +19,7 @@ describe("Topbar", () => {
     $rootScope = $injector.get("$rootScope");
     $ctrl = _$componentController_("topbar", {});
     sinon.stub($ctrl.Authentication, "update");
-    $ctrl.Authentication.update.returns($q((resolve) => {
-      resolve(userData);
-    }));
+    $ctrl.Authentication.update.returns($q.resolve(userData));
   }));
 
   describe("Controller", () => {
@@ -49,9 +47,7 @@ describe("Topbar", () => {
       });
       sinon.stub($state, "go");
       sinon.stub($ctrl.Authentication, "logout");
-      $ctrl.Authentication.logout.returns($q((resolve) => {
-        resolve(undefined);
-      }));
+      $ctrl.Authentication.logout.returns($q.resolve(undefined));
       $ctrl.logOut();
       $rootScope.$apply();
       expect($state.go).to.have.been.calledWith("login");

--- a/client/app/components/group/_pickupList/pickupList.spec.js
+++ b/client/app/components/group/_pickupList/pickupList.spec.js
@@ -245,9 +245,7 @@ describe("PickupList", () => {
     it("pickupEditCreate dialog is called and updates pickup list", () => {
       $ctrl.allPickups = [];
       sinon.stub($ctrl.$mdDialog, "show");
-      $ctrl.$mdDialog.show.returns($q((resolve) => resolve({
-        "collector_ids": []
-      })));
+      $ctrl.$mdDialog.show.returns($q.resolve({ "collector_ids": [] }));
       $ctrl.openCreatePickupPanel();
       $rootScope.$apply();
       expect($ctrl.allPickups).to.deep.equal([{ "collector_ids": [] }]);

--- a/client/app/components/group/_pickupList/pickupListItem/pickupListItem.spec.js
+++ b/client/app/components/group/_pickupList/pickupListItem/pickupListItem.spec.js
@@ -1,7 +1,7 @@
 import PickupListItemModule from "./pickupListItem";
 
 describe("PickupListItem", () => {
-  let $log, $componentController, $httpBackend, $q;
+  let $log, $componentController, $httpBackend;
 
   let { module } = angular.mock;
 
@@ -14,9 +14,6 @@ describe("PickupListItem", () => {
     $log.reset();
     $httpBackend = $injector.get("$httpBackend");
     $componentController = $injector.get("$componentController");
-    $q = $injector.get("$q");
-
-    pickupData.storePromise = $q((resolve) => resolve(storeData));
   }));
 
   afterEach(() => {
@@ -33,10 +30,6 @@ describe("PickupListItem", () => {
     ],
     "max_collectors": 3,
     "store": 9
-  };
-
-  let storeData = {
-    "id": 9
   };
 
   describe("Controller", () => {

--- a/client/app/components/group/groupDetail/groupDetail.spec.js
+++ b/client/app/components/group/groupDetail/groupDetail.spec.js
@@ -48,7 +48,7 @@ describe("GroupDetail", () => {
       let groupData = { id: 9834 };
       sinon.stub($ctrl.$mdDialog, "show");
       sinon.stub($ctrl.$state, "go");
-      $ctrl.$mdDialog.show.returns($q((resolve) => resolve()));
+      $ctrl.$mdDialog.show.returns($q.resolve());
       Authentication.data = { id: 1 };
       $httpBackend.expectPOST(`/api/groups/${groupData.id}/leave/`).respond(200);
       sinon.stub($ctrl.CurrentGroup, "persistCurrentGroup");
@@ -66,7 +66,7 @@ describe("GroupDetail", () => {
       let groupData = { id: 98238 };
       sinon.stub($ctrl.$state, "go");
       sinon.stub($ctrl.$mdDialog, "show");
-      $ctrl.$mdDialog.show.returns($q((resolve) => resolve()));
+      $ctrl.$mdDialog.show.returns($q.resolve());
       $httpBackend.expectPOST(`/api/groups/${groupData.id}/leave/`).respond(400);
       Object.assign($ctrl, { groupData });
       $ctrl.leaveGroup();

--- a/client/app/components/groupInfo/groupInfo.spec.js
+++ b/client/app/components/groupInfo/groupInfo.spec.js
@@ -74,9 +74,7 @@ describe("GroupInfo", () => {
       inject(($q, $rootScope) => {
         sinon.stub($ctrl.$mdDialog, "show");
         sinon.stub($ctrl.$state, "go");
-        $ctrl.$mdDialog.show.returns($q((resolve) => {
-          resolve(1337);
-        }));
+        $ctrl.$mdDialog.show.returns($q.resolve(1337));
         $ctrl.openJoinGroup();
         $rootScope.$apply();
         expect($ctrl.$state.go).to.have.been.calledWith( "group", { groupId: 1337 } );

--- a/client/app/components/home/home.spec.js
+++ b/client/app/components/home/home.spec.js
@@ -66,9 +66,7 @@ describe("Home", () => {
       let $ctrl = $componentController("home", {});
       sinon.stub($ctrl.$state, "go");
       sinon.stub($ctrl.$mdDialog, "show");
-      $ctrl.$mdDialog.show.returns($q((resolve) => {
-        resolve(1337);
-      }));
+      $ctrl.$mdDialog.show.returns($q.resolve(1337));
       $ctrl.$onInit();
       $httpBackend.flush();
       expect($ctrl.$state.go).to.have.been.calledWith( "group", { groupId: 1337 } );

--- a/client/app/components/passwordreset/passwordreset.spec.js
+++ b/client/app/components/passwordreset/passwordreset.spec.js
@@ -35,9 +35,7 @@ describe("Passwordreset", () => {
     it("resets password", () => {
       let $ctrl = $componentController("passwordreset", {});
       sinon.stub($ctrl.User, "resetPassword");
-      $ctrl.User.resetPassword.returns($q((resolve) => {
-        resolve();
-      }));
+      $ctrl.User.resetPassword.returns($q.resolve());
       $ctrl.doReset();
       $rootScope.$apply();
       expect($ctrl.successful).to.be.true;
@@ -46,9 +44,7 @@ describe("Passwordreset", () => {
     it("fails resetting password", () => {
       let $ctrl = $componentController("passwordreset", {});
       sinon.stub($ctrl.User, "resetPassword");
-      $ctrl.User.resetPassword.returns($q((resolve, reject) => {
-        reject({ data: "message" });
-      }));
+      $ctrl.User.resetPassword.returns($q.reject({ data: "message" }));
       $ctrl.doReset();
       $rootScope.$apply();
       expect($ctrl.error).to.equal("message");

--- a/client/app/components/userDetail/userDetail.controller.js
+++ b/client/app/components/userDetail/userDetail.controller.js
@@ -38,6 +38,12 @@ class UserDetailController {
   stopEdit() {
     this.editEnabled = false;
   }
+
+  mailIsDifferent(user) {
+    return angular.isDefined(user.unverified_email)
+      && user.unverified_email !== null
+      && user.email !== user.unverified_email;
+  }
 }
 
 export default UserDetailController;

--- a/client/app/components/userDetail/userDetail.html
+++ b/client/app/components/userDetail/userDetail.html
@@ -20,7 +20,12 @@
     <div layout-padding>
       <div ng-if="!$ctrl.editEnabled">
         <h3 layout-padding>
-          <i class="fa fa-envelope-o" aria-hidden="true"></i> {{ $ctrl.userdata.email }}
+          <i class="fa fa-envelope-o" aria-hidden="true"></i>
+          {{ $ctrl.userdata.email }}
+          <span ng-if="$ctrl.mailIsDifferent($ctrl.userdata)">
+            <md-icon md-font-icon="fa fa-arrow-right"></md-icon>
+            <a ui-sref="notifications">{{ $ctrl.userdata.unverified_email }}</a>
+          </span>
         </h3>
         <expandable-panel content="$ctrl.userdata.description" markdown="true" collapse="1000"></expandable-panel>
       </div>

--- a/client/app/components/userDetail/userDetail.spec.js
+++ b/client/app/components/userDetail/userDetail.spec.js
@@ -56,9 +56,7 @@ describe("UserDetail", () => {
     }));
 
     it("makes page non-editable", () => {
-      $ctrl.Authentication.update.returns($q((resolve) => {
-        resolve({ id: 2 });
-      }));
+      $ctrl.Authentication.update.returns($q.resolve({ id: 2 }));
       $ctrl.$onChanges({ userdata: { currentValue: { id: 666 } } });
       expect($ctrl.editable).to.be.undefined;
       $scope.$apply();
@@ -66,9 +64,7 @@ describe("UserDetail", () => {
     });
 
     it("makes page editable", () => {
-      $ctrl.Authentication.update.returns($q((resolve) => {
-        resolve({ id: 666 });
-      }));
+      $ctrl.Authentication.update.returns($q.resolve({ id: 666 }));
       $ctrl.$onChanges({ userdata: { currentValue: { id: 666 } } });
       expect($ctrl.editable).to.be.undefined;
       $scope.$apply();
@@ -81,9 +77,7 @@ describe("UserDetail", () => {
       $ctrl.editEnable();
       expect($ctrl.editEnabled).to.be.true;
       $ctrl.editData.email = "another@mail.com";
-      $ctrl.User.save.withArgs($ctrl.editData).returns($q((resolve) => {
-        resolve($ctrl.editData);
-      }));
+      $ctrl.User.save.withArgs($ctrl.editData).returns($q.resolve($ctrl.editData));
       $ctrl.submitEdit();
       $scope.$apply();
       expect($ctrl.editEnabled).to.be.false;
@@ -99,9 +93,7 @@ describe("UserDetail", () => {
       });
       it("goes to login when password is changed", () => {
         $ctrl.isChangePassword = true;
-        $ctrl.User.save.returns($q((resolve) => {
-          resolve();
-        }));
+        $ctrl.User.save.returns($q.resolve());
         $ctrl.submitEdit();
         $scope.$apply();
         expect($ctrl.$state.go).to.have.been.calledWith("login");
@@ -109,9 +101,7 @@ describe("UserDetail", () => {
 
       it("does not go to login when password is not changed", () => {
         $ctrl.isChangePassword = false;
-        $ctrl.User.save.returns($q((resolve) => {
-          resolve();
-        }));
+        $ctrl.User.save.returns($q.resolve());
         $ctrl.submitEdit();
         $scope.$apply();
         expect($ctrl.$state.go).to.not.have.been.called;
@@ -119,9 +109,7 @@ describe("UserDetail", () => {
 
       it("does not go to login when request fails", () => {
         $ctrl.isChangePassword = true;
-        $ctrl.User.save.returns($q((resolve, reject) => {
-          reject({ data: "error" });
-        }));
+        $ctrl.User.save.returns($q.reject({ data: "error" }));
         $ctrl.submitEdit();
         $scope.$apply();
         expect($ctrl.$state.go).to.not.have.been.called;

--- a/client/app/components/userDetail/userDetail.spec.js
+++ b/client/app/components/userDetail/userDetail.spec.js
@@ -114,6 +114,27 @@ describe("UserDetail", () => {
         $scope.$apply();
         expect($ctrl.$state.go).to.not.have.been.called;
       });
+
+      it("checks if mail changed", () => {
+        expect($ctrl.mailIsDifferent({
+          email: "l@l.de",
+          "unverified_email": "lars@l.de"
+        })).to.be.true;
+
+        expect($ctrl.mailIsDifferent({
+          email: "l@l.de",
+          "unverified_email": "l@l.de"
+        })).to.be.false;
+
+        expect($ctrl.mailIsDifferent({
+          email: "l@l.de",
+          "unverified_email": null
+        })).to.be.false;
+
+        expect($ctrl.mailIsDifferent({
+          email: "l@l.de"
+        })).to.be.false;
+      });
     });
 
   });

--- a/client/app/components/verifyMail/verifyMail.component.js
+++ b/client/app/components/verifyMail/verifyMail.component.js
@@ -5,7 +5,7 @@ import "./verifyMail.styl";
 let verifyMailComponent = {
   restrict: "",
   bindings: {
-    email: "<",
+    user: "<",
     error: "<"
   },
   template,

--- a/client/app/components/verifyMail/verifyMail.controller.js
+++ b/client/app/components/verifyMail/verifyMail.controller.js
@@ -1,4 +1,9 @@
 class VerifyMailController {
+  mailIsDifferent(user) {
+    return angular.isDefined(user.unverified_email)
+      && user.unverified_email !== null
+      && user.email !== user.unverified_email;
+  }
 }
 
 export default VerifyMailController;

--- a/client/app/components/verifyMail/verifyMail.html
+++ b/client/app/components/verifyMail/verifyMail.html
@@ -1,5 +1,13 @@
 <h1 translate="VERIFYMAIL.TITLE"></h1>
-{{ $ctrl.email }}
+<div>
+  <span>
+    {{ $ctrl.user.email  }}
+  </span>
+  <span ng-if="$ctrl.mailIsDifferent($ctrl.user)">
+    <md-icon md-font-icon="fa fa-arrow-right"></md-icon>
+    {{ $ctrl.user.unverified_email }}
+  </span>
+<div>
 <div ng-switch="$ctrl.error">
   <div ng-switch-when="false">
     <h4 translate="VERIFYMAIL.SUCCESS"></h4>

--- a/client/app/components/verifyMail/verifyMail.js
+++ b/client/app/components/verifyMail/verifyMail.js
@@ -28,6 +28,9 @@ let verifyMailModule = angular.module("verifyMail", [
           .then(() => false)
           .catch((err) => err);
         }
+      },
+      ncyBreadcrumb: {
+        label: "{{'VERIFYMAIL.TITLE' | translate}}"
       }
     });
   hookProvider.setup("verifyMail", { authenticated: true, anonymous: "login" });

--- a/client/app/components/verifyMail/verifyMail.js
+++ b/client/app/components/verifyMail/verifyMail.js
@@ -20,8 +20,8 @@ let verifyMailModule = angular.module("verifyMail", [
       url: "/verify-mail?key",
       component: "verifyMail",
       resolve: {
-        email: (Authentication) => {
-          return Authentication.update().then((data) => data.email);
+        user: (Authentication) => {
+          return Authentication.update();
         },
         error: (User, $stateParams) => {
           return User.verifyMail($stateParams.key)

--- a/client/app/components/verifyMail/verifyMail.spec.js
+++ b/client/app/components/verifyMail/verifyMail.spec.js
@@ -43,7 +43,7 @@ describe("VerifyMail", () => {
       $rootScope.$apply();
       expect($state.current.component).to.equal("verifyMail");
       inject(($injector) => {
-        expect($injector.invoke($state.current.resolve.email)).to.eventually.equal("user@example.com");
+        expect($injector.invoke($state.current.resolve.user)).to.eventually.deep.equal({ email: "user@example.com" });
         expect($injector.invoke($state.current.resolve.error)).to.eventually.be.false;
       });
       $rootScope.$apply();
@@ -55,10 +55,38 @@ describe("VerifyMail", () => {
       $rootScope.$apply();
       expect($state.current.component).to.equal("verifyMail");
       inject(($injector) => {
-        expect($injector.invoke($state.current.resolve.email)).to.eventually.equal("user@example.com");
+        expect($injector.invoke($state.current.resolve.user)).to.eventually.deep.equal({ email: "user@example.com" });
         expect($injector.invoke($state.current.resolve.error)).to.eventually.deep.equal({ error: "wontfix" });
       });
       $rootScope.$apply();
+    });
+  });
+
+  describe("Controller", () => {
+    let $ctrl;
+    beforeEach(inject((_$componentController_) => {
+      $ctrl = _$componentController_("verifyMail", { });
+    }));
+
+    it("checks if mail changed", () => {
+      expect($ctrl.mailIsDifferent({
+        email: "l@l.de",
+        "unverified_email": "lars@l.de"
+      })).to.be.true;
+
+      expect($ctrl.mailIsDifferent({
+        email: "l@l.de",
+        "unverified_email": "l@l.de"
+      })).to.be.false;
+
+      expect($ctrl.mailIsDifferent({
+        email: "l@l.de",
+        "unverified_email": null
+      })).to.be.false;
+
+      expect($ctrl.mailIsDifferent({
+        email: "l@l.de"
+      })).to.be.false;
     });
   });
 });

--- a/client/app/components/verifyMail/verifyMail.spec.js
+++ b/client/app/components/verifyMail/verifyMail.spec.js
@@ -25,9 +25,7 @@ describe("VerifyMail", () => {
     Authentication = $injector.get("Authentication");
     sinon.stub(Authentication, "update");
     $q = $injector.get("$q");
-    Authentication.update.returns($q((resolve) => {
-      resolve({ email: "user@example.com" });
-    }));
+    Authentication.update.returns($q.resolve({ email: "user@example.com" }));
     User = $injector.get("User");
     sinon.stub(User, "verifyMail");
   }));
@@ -40,9 +38,7 @@ describe("VerifyMail", () => {
 
   describe("Route", () => {
     it("goes to state", () => {
-      User.verifyMail.withArgs("abc").returns($q((resolve) => {
-        resolve();
-      }));
+      User.verifyMail.withArgs("abc").returns($q.resolve());
       $state.go("verifyMail", { key: "abc" });
       $rootScope.$apply();
       expect($state.current.component).to.equal("verifyMail");
@@ -54,9 +50,7 @@ describe("VerifyMail", () => {
     });
 
     it("sets error on reject", () => {
-      User.verifyMail.withArgs("abc").returns($q((resolve, reject) => {
-        reject({ error: "wontfix" });
-      }));
+      User.verifyMail.withArgs("abc").returns($q.reject({ error: "wontfix" }));
       $state.go("verifyMail", { key: "abc" });
       $rootScope.$apply();
       expect($state.current.component).to.equal("verifyMail");


### PR DESCRIPTION
- show new mail on verifyMail page
- show unverified mail in userDetail

I just noticed that the backend should actually return the verified result. So the change on the verifyMail page is more of a workaround for now..