### PR TITLE
Issue #474: Replaced Create Pickup button with Manage Pickup Dates button. Removed Delete Pickup Dates button from pickup-list-item,

### DIFF
--- a/client/app/components/group/_pickupList/pickupList.html
+++ b/client/app/components/group/_pickupList/pickupList.html
@@ -4,9 +4,9 @@
   <div ng-show="$ctrl.options.showTopbar">
     <h3 class="md-title"><i class="icon fa fa-shopping-basket" aria-hidden="true"></i>  {{$ctrl.options.header}}</h3>
     <div style="display: inline-block">
-      <md-button aria-label="{{'BUTTON.CREATE' | translate}}" ng-show="$ctrl.options.showCreateButton" class="md-primary" aria-label="Create Pickup" ng-click="$ctrl.openCreatePickupPanel($event)">
-      <i style="font-size: 1.2em;" class="fa fa-plus-circle" aria-hidden="true"></i>
-        <span translate="BUTTON.CREATE"></span>
+      <md-button aria-label="{{'STOREDETAIL.MANAGE_PICKUP_DATES' | translate}}" ng-show="$ctrl.options.showCreateButton" class="md-primary" aria-label="Check and manage the pickups" ui-sref="pickupManage">
+      <i style="font-size: 1.2em;" class="fa fa-clock-o" aria-hidden="true"></i>
+        <span translate="STOREDETAIL.MANAGE_PICKUP_DATES"></span>
       </md-button>
       <md-menu>
         <md-button aria-label="{{'PICKUPLIST.FILTER' | translate}}" class="small" ng-click="$mdMenu.open($event)">
@@ -50,7 +50,6 @@
       <pickup-list-item
         ng-repeat-end
         show-detail="$ctrl.options.showDetail"
-        on-delete="$ctrl.delete(pickup)"
         on-join="$ctrl.joinPickup(pickup.id)"
         on-leave="$ctrl.leavePickup(pickup.id)"
         data="pickup"

--- a/client/app/components/group/_pickupList/pickupListItem/pickupListItem.html
+++ b/client/app/components/group/_pickupList/pickupListItem/pickupListItem.html
@@ -14,12 +14,6 @@
           {{$ctrl.data.date | date:'fullDate'}}
         </span>
       </span>
-      <md-button ng-if="!$ctrl.showStoreDetail && !$ctrl.data.collector_ids.length" class="md-icon-button md-warn" ng-click="$ctrl.onDelete($ctrl.data, $event)" promise-btn aria-label="{{ 'PICKUPLIST.ITEM.DELETE' | translate }}">
-        <md-tooltip>
-          <span translate="PICKUPLIST.ITEM.DELETE"></span>
-        </md-tooltip>
-        <i class="fa fa-trash-o"></i>
-      </md-button>
     </span>
     <div class="pickupList-pickup-people">
       <a class="pickuplist-pickup-person" ng-repeat="id in $ctrl.data.collector_ids" ui-sref="userDetail({ id })">

--- a/client/app/components/group/store/storeDetail.html
+++ b/client/app/components/group/store/storeDetail.html
@@ -5,12 +5,6 @@
         <i class="fa fa-shopping-cart" aria-hidden="true"></i>
         {{$ctrl.storedata.name}}
       </h1>
-      <md-button class="md-icon-button" ui-sref="pickupManage" aria-label="{{ 'STOREDETAIL.MANAGE' | translate }}">
-        <md-tooltip md-direction="left">
-          <span translate="STOREDETAIL.MANAGE"></span>
-        </md-tooltip>
-        <i class="fa fa-clock-o"></i>
-      </md-button>
       <md-button class="md-icon-button" ui-sref="storeEdit({storeId: $ctrl.storedata.id})" aria-label="{{ 'STOREDETAIL.EDIT' | translate }}">
         <md-tooltip md-direction="left">
           <span translate="STOREDETAIL.EDIT"></span>

--- a/client/app/locales/locale-de.json
+++ b/client/app/locales/locale-de.json
@@ -59,7 +59,8 @@
   "STOREDETAIL": {
     "EDIT": "Betrieb bearbeiten",
     "ADDRESS": "Adresse",
-    "MANAGE": "Abholzeiten prüfen und ändern"
+    "MANAGE": "Abholzeiten prüfen und ändern",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Name",

--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -60,7 +60,8 @@
   "STOREDETAIL": {
     "EDIT": "Edit store",
     "ADDRESS": "Address",
-    "MANAGE": "Check and manage the pickups"
+    "MANAGE": "Check and manage the pickups",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Name",

--- a/client/app/locales/locale-eo.json
+++ b/client/app/locales/locale-eo.json
@@ -59,7 +59,8 @@
   "STOREDETAIL": {
     "EDIT": "Redakti vendejon",
     "ADDRESS": "Adreso",
-    "MANAGE": "Check and manage the pickups"
+    "MANAGE": "Check and manage the pickups",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Nomo",

--- a/client/app/locales/locale-es.json
+++ b/client/app/locales/locale-es.json
@@ -59,7 +59,8 @@
   "STOREDETAIL": {
     "EDIT": "Editar tienda",
     "ADDRESS": "Dirección",
-    "MANAGE": "Check and manage the pickups"
+    "MANAGE": "Check and manage the pickups",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Nombre",

--- a/client/app/locales/locale-fr.json
+++ b/client/app/locales/locale-fr.json
@@ -59,7 +59,8 @@
   "STOREDETAIL": {
     "EDIT": "Traiter magasin",
     "ADDRESS": "Adresse",
-    "MANAGE": "Check and manage the pickups"
+    "MANAGE": "Check and manage the pickups",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Nom",

--- a/client/app/locales/locale-it.json
+++ b/client/app/locales/locale-it.json
@@ -59,7 +59,8 @@
   "STOREDETAIL": {
     "EDIT": "Modifica negozi",
     "ADDRESS": "Indirizzo",
-    "MANAGE": "Check and manage the pickups"
+    "MANAGE": "Check and manage the pickups",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Name",

--- a/client/app/locales/locale-ru.json
+++ b/client/app/locales/locale-ru.json
@@ -59,7 +59,8 @@
   "STOREDETAIL": {
     "EDIT": "Внести изменения",
     "ADDRESS": "Адрес",
-    "MANAGE": "Check and manage the pickups"
+    "MANAGE": "Check and manage the pickups",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Name",

--- a/client/app/locales/locale-sv.json
+++ b/client/app/locales/locale-sv.json
@@ -59,7 +59,8 @@
   "STOREDETAIL": {
     "EDIT": "Redigera butik",
     "ADDRESS": "Adress",
-    "MANAGE": "Hantera upphämtningarna"
+    "MANAGE": "Hantera upphämtningarna",
+    "MANAGE_PICKUP_DATES": "Manage pickup dates"
   },
   "STOREEDIT": {
     "NAME": "Namn",


### PR DESCRIPTION
I have also removed 'Check and Manage Pickup Dates' from the top bar/header of store details as we now have a more prominent 'Manage Pickup Dates' button.
I have added a new phrase in locale files in English. I have not updated the phrases in other languages as I am not familiar with them. Please check the attached screenshot.
Thanks.
![scrshot 1](https://cloud.githubusercontent.com/assets/8210079/26803144/bf0ff0b6-4a60-11e7-8d28-d9f17f275236.png)
