### PR TITLE
show message in history if pickup was missed

### DIFF
--- a/client/app/locales/locale-en.json
+++ b/client/app/locales/locale-en.json
@@ -199,6 +199,7 @@
     "SERIES_MODIFY": "changed the settings of a recurring pick-up",
     "SERIES_DELETE": "deleted a recurring pick-up",
     "PICKUP_DONE": "did a pick-up at {{store_name}}",
+    "PICKUP_MISSED": "A pickup at {{store_name}} was missed!",
     "PICKUP_JOIN": "signed up to do a pick-up at {{store_name}}",
     "PICKUP_LEAVE": "stepped back from doing a pick-up at {{store_name}}",
     "LOAD_MORE": "load more ...",


### PR DESCRIPTION
showed up as PICKUP_DONE before.

Goes along with https://github.com/yunity/foodsaving-backend/pull/312