### PR TITLE
rename pickup comment to description

### DIFF
--- a/client/app/components/group/_pickupEditCreate/pickupEditCreate.controller.js
+++ b/client/app/components/group/_pickupEditCreate/pickupEditCreate.controller.js
@@ -39,7 +39,7 @@ class pickupEditCreateController {
         id: this.data.editData.id,
         "max_collectors": this.data.editData.max_collectors,
         store: this.data.editData.store,
-        comment: this.data.editData.comment
+        description: this.data.editData.description
       };
 
       this.time = new Date();

--- a/client/app/components/group/_pickupEditCreate/pickupEditCreate.html
+++ b/client/app/components/group/_pickupEditCreate/pickupEditCreate.html
@@ -77,7 +77,7 @@
 
       <md-input-container>
         <label translate="CREATEPICKUP.COMMENT"></label>
-        <input ng-model="$ctrl.pickupData.comment"></input>
+        <input ng-model="$ctrl.pickupData.description"></input>
       </md-input-container>
 
       <div ng-if="$ctrl.isCreate" layout="row" layout-align="end center">

--- a/client/app/components/group/_pickupEditCreate/pickupEditCreate.spec.js
+++ b/client/app/components/group/_pickupEditCreate/pickupEditCreate.spec.js
@@ -149,7 +149,7 @@ describe("pickupEditCreate", () => {
             date,
             "max_collectors": 5,
             store: 3,
-            comment: ""
+            description: ""
           }
         }
       });
@@ -167,7 +167,7 @@ describe("pickupEditCreate", () => {
         date: new Date(2016,2,25,15,22),
         store: 3,
         "max_collectors": 5,
-        comment: ""
+        description: ""
       });
       expect($ctrl.$mdDialog.hide).to.have.been.called;
     });
@@ -186,7 +186,7 @@ describe("pickupEditCreate", () => {
               byDay: ["MO"]
             },
             store: 3,
-            comment: ""
+            description: ""
           }
         }
       });
@@ -208,7 +208,7 @@ describe("pickupEditCreate", () => {
           byDay: ["MO", "TU"]
         },
         store: 3,
-        comment: ""
+        description: ""
       });
       expect($ctrl.$mdDialog.hide).to.have.been.called;
     });

--- a/client/app/components/group/_pickupList/pickupList.spec.js
+++ b/client/app/components/group/_pickupList/pickupList.spec.js
@@ -242,14 +242,14 @@ describe("PickupList", () => {
     it("pickupEditCreate dialog is called and updates pickup list", () => {
       $ctrl.allPickups = [];
       sinon.stub($ctrl.$mdDialog, "show");
-      let pickup = { id: 5, comment: "bla" };
+      let pickup = { id: 5, description: "bla" };
       $ctrl.allPickups = [pickup];
-      $ctrl.$mdDialog.show.returns($q.resolve({ id: 5, comment: "har" }));
+      $ctrl.$mdDialog.show.returns($q.resolve({ id: 5, description: "har" }));
       $ctrl.openEditPickupPanel({}, pickup);
       $rootScope.$apply();
-      expect($ctrl.allPickups).to.deep.equal([{ id: 5, comment: "har" }]);
+      expect($ctrl.allPickups).to.deep.equal([{ id: 5, description: "har" }]);
       // should keep reference and replace content via angular.copy
-      expect(pickup).to.deep.equal({ id: 5, comment: "har" });
+      expect(pickup).to.deep.equal({ id: 5, description: "har" });
     });
   });
 

--- a/client/app/components/group/_pickupList/pickupListItem/pickupListItem.html
+++ b/client/app/components/group/_pickupList/pickupListItem/pickupListItem.html
@@ -20,8 +20,8 @@
           </md-button>
         </span>
       </div>
-      <div ng-if="$ctrl.data.comment !== ''" class="md-caption comment">
-        {{ $ctrl.data.comment }}
+      <div ng-if="$ctrl.data.description !== ''" class="md-caption description">
+        {{ $ctrl.data.description }}
       </div>
       <div class="people">
         <profile-picture ng-repeat="userId in $ctrl.data.collector_ids" user-id="userId" size="20"></profile-picture>

--- a/client/app/components/group/_pickupList/pickupListItem/pickupListItem.styl
+++ b/client/app/components/group/_pickupList/pickupListItem/pickupListItem.styl
@@ -37,7 +37,7 @@ pickup-list-item
           width 30px
           margin 0
           padding 0
-      .comment
+      .description
         margin-bottom 6px
       .people .counter
         display inline-block


### PR DESCRIPTION
Frontend and backend should be merged at the same time: https://github.com/yunity/foodsaving-backend/pull/329

Rationale is on the backend PR.

I didn't rename the translation keys, as syncing it with transifex is a pain.