### PR TITLE
Revert "chore(package): update file-loader to version 1.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint": "^4.1.0",
     "eslint-config-angular": "^0.5.0",
     "eslint-plugin-angular": "^3.0.0",
-    "file-loader": "^1.0.0",
+    "file-loader": "^0.11.1",
     "fs-walk": "0.0.1",
     "gulp": "^3.9.0",
     "gulp-eslint": "^4.0.0",


### PR DESCRIPTION
Reverts yunity/foodsaving-frontend#576

Something something about require and export seems to be buggy: https://github.com/webpack-contrib/file-loader/issues/181
I'll just wait.